### PR TITLE
Two more patches for iPhone6 restore

### DIFF
--- a/src/restore.c
+++ b/src/restore.c
@@ -1451,6 +1451,15 @@ int restore_send_baseband_data(restored_client_t restore, struct idevicerestore_
 		tss_request_add_common_tags(request, parameters, NULL);
 		tss_request_add_baseband_tags(request, parameters, NULL);
 
+		plist_t node = plist_access_path(build_identity, 2, "Info", "FDRSupport");
+		if (node && plist_get_node_type(node) == PLIST_BOOLEAN) {
+			uint8_t b = 0;
+			plist_get_bool_val(node, &b);
+			if (b) {
+				plist_dict_set_item(request, "ApProductionMode", plist_new_bool(1));
+				plist_dict_set_item(request, "ApSecurityMode", plist_new_bool(1));
+			}
+		}
 		if (idevicerestore_debug)
 			debug_plist(request);
 

--- a/src/tss.c
+++ b/src/tss.c
@@ -221,15 +221,6 @@ int tss_request_add_ap_img4_tags(plist_t request, plist_t parameters) {
 		return -1;
 	}
 
-	/* ApECID */
-	node = plist_dict_get_item(parameters, "ApECID");
-	if (!node || plist_get_node_type(node) != PLIST_UINT) {
-		error("ERROR: Unable to find required ApECID in parameters\n");
-		return -1;
-	}
-	plist_dict_set_item(request, "ApECID", plist_copy(node));
-	node = NULL;
-
 	/* ApNonce */
 	node = plist_dict_get_item(parameters, "ApNonce");
 	if (!node || plist_get_node_type(node) != PLIST_DATA) {
@@ -300,15 +291,6 @@ int tss_request_add_ap_img3_tags(plist_t request, plist_t parameters) {
 	/* @APTicket */
 	plist_dict_set_item(request, "@APTicket", plist_new_bool(1));
 
-	/* ApECID */
-	node = plist_dict_get_item(parameters, "ApECID");
-	if (!node || plist_get_node_type(node) != PLIST_UINT) {
-		error("ERROR: Unable to find required ApECID in parameters\n");
-		return -1;
-	}
-	plist_dict_set_item(request, "ApECID", plist_copy(node));
-	node = NULL;
-
 	/* ApBoardID */
 	node = plist_dict_get_item(request, "ApBoardID");
 	if (!node || plist_get_node_type(node) != PLIST_UINT) {
@@ -347,6 +329,15 @@ int tss_request_add_ap_img3_tags(plist_t request, plist_t parameters) {
 
 int tss_request_add_common_tags(plist_t request, plist_t parameters, plist_t overrides) {
 	plist_t node = NULL;
+
+	/* ApECID */
+	node = plist_dict_get_item(parameters, "ApECID");
+	if (!node || plist_get_node_type(node) != PLIST_UINT) {
+		error("ERROR: Unable to find required ApECID in parameters\n");
+		return -1;
+	}
+	plist_dict_set_item(request, "ApECID", plist_copy(node));
+	node = NULL;
 
 	/* UniqueBuildID */
 	node = plist_dict_get_item(parameters, "UniqueBuildID");
@@ -750,6 +741,9 @@ plist_t tss_request_send(plist_t tss_request, const char* server_url_string) {
 			break;
 		} else if (status_code == 100) {
 			// server error, most likely the request was malformed
+			break;
+		} else if (status_code == 126) {
+			// An internal error occured, most likely the request was malformed
 			break;
 		} else {
 			error("ERROR: tss_send_request: Unhandled status code %d\n", status_code);


### PR DESCRIPTION
These two patches should be enough to restore devices that already have valid data (maybe have working iOS 8.x and not in restore/DFU mode) but upgrading from older or restore mode still needs some more extensive changes.
