### PR TITLE
Use fseeko64 and related functions; mingw32 doesn't know about fseeko;

### DIFF
--- a/src/asr.c
+++ b/src/asr.c
@@ -199,14 +199,14 @@ int asr_perform_validation(asr_client_t asr, const char* filesystem) {
 	plist_t payload_info = NULL;
 	int attempts = 0;
 
-	file = fopen(filesystem, "rb");
+	file = fopen64(filesystem, "rb");
 	if (file == NULL) {
 		return -1;
 	}
 
-	fseeko(file, 0, SEEK_END);
-	length = ftello(file);
-	fseeko(file, 0, SEEK_SET);
+	fseeko64(file, 0, SEEK_END);
+	length = ftello64(file);
+	fseeko64(file, 0, SEEK_SET);
 
 	payload_info = plist_new_dict();
 	plist_dict_set_item(payload_info, "Port", plist_new_uint(1));
@@ -300,7 +300,7 @@ int asr_handle_oob_data_request(asr_client_t asr, plist_t packet, FILE* file) {
 		return -1;
 	}
 
-	fseeko(file, oob_offset, SEEK_SET);
+	fseeko64(file, oob_offset, SEEK_SET);
 	if (fread(oob_data, 1, oob_length, file) != oob_length) {
 		error("ERROR: Unable to read OOB data from filesystem offset: %s\n",
 		      strerror(errno));
@@ -323,16 +323,16 @@ int asr_send_payload(asr_client_t asr, const char* filesystem) {
 	off_t i, length, bytes = 0;
 	double progress = 0;
 
-	file = fopen(filesystem, "rb");
+	file = fopen64(filesystem, "rb");
 	if (file == NULL) {
 		error("ERROR: Unable to open filesystem image %s: %s\n",
 		      filesystem, strerror(errno));
 		return -1;
 	}
 
-	fseeko(file, 0, SEEK_END);
-	length = ftello(file);
-	fseeko(file, 0, SEEK_SET);
+	fseeko64(file, 0, SEEK_END);
+	length = ftello64(file);
+	fseeko64(file, 0, SEEK_SET);
 
 	int chunk = 0;
 	int add_checksum = 0;

--- a/src/common.c
+++ b/src/common.c
@@ -154,14 +154,14 @@ int read_file(const char* filename, void** data, size_t* size) {
 	*size = 0;
 	*data = NULL;
 
-	file = fopen(filename, "rb");
+	file = fopen64(filename, "rb");
 	if (file == NULL) {
 		error("read_file: File %s not found\n", filename);
 		return -1;
 	}
 
-	fseeko(file, 0, SEEK_END);
-	length = ftello(file);
+	fseeko64(file, 0, SEEK_END);
+	length = ftello64(file);
 	rewind(file);
 
 	buffer = (char*) malloc(length);

--- a/src/download.c
+++ b/src/download.c
@@ -107,7 +107,7 @@ int download_to_file(const char* url, const char* filename, int enable_progress)
 		return -1;
 	}
 
-	FILE* f = fopen(filename, "wb");
+	FILE* f = fopen64(filename, "wb");
 	if (!f) {
 		error("ERROR: cannot open '%s' for writing\n", filename);
 		return -1;
@@ -135,7 +135,7 @@ int download_to_file(const char* url, const char* filename, int enable_progress)
 	curl_easy_perform(handle);
 	curl_easy_cleanup(handle);
 
-	off_t sz = ftello(f);
+	off_t sz = ftello64(f);
 	fclose(f);
 
 	if ((sz == 0) || (sz == (off_t)-1)) {


### PR DESCRIPTION
I'm compiling idevicerestore on mingw32. 
The fseeko and ftello functions aren't defined natively on mingw32, but fseeko64 and ftello64 are. 
In this patch, I've replaced the calls to fopen, fseeko and ftello to fopen64, fseeko64 and ftello64, allowing compilation on mingw32 to succeed.