### PR TITLE
Silenced compliler errors

### DIFF
--- a/src/restore.c
+++ b/src/restore.c
@@ -2026,7 +2026,7 @@ int restore_device(struct idevicerestore_client_t* client, plist_t build_identit
 	idevice_t device = NULL;
 	restored_client_t restore = NULL;
 	restored_error_t restore_error = RESTORE_E_SUCCESS;
-	thread_t fdr_thread = NULL;
+	thread_t fdr_thread = 0;
 
 	restore_finished = 0;
 


### PR DESCRIPTION
and in restore.c, thread_t is not a pointer but an interger handle
so don't initialize it from a pointer type (NULL is a pointer).