### PR TITLE
Fix invalid personalization tag offset (iOS 12 flashing for iPhone 8/8+/X)

### DIFF
--- a/src/img4.c
+++ b/src/img4.c
@@ -164,6 +164,8 @@ int img4_stitch_component(const char* component_name, const unsigned char* compo
 			memcpy((void*)tag, "rdtr", 4);
 		} else if (strcmp(component_name, "RestoreSEP") == 0) {
 			memcpy((void*)tag, "rsep", 4);
+		} else if (strcmp(component_name, "AppleLogo") == 0) {
+			memcpy((void*)tag, "rlgo", 4);
 		}
 	}
 


### PR DESCRIPTION
The first commit addresses the invalid personalization offset.
The second commit adds something I found that Apple xx 2 is doing, so I guess we should do the same.

#226 