### PR TITLE
restore: Pending fixes for iOS 12.1 and iOS 12.1.1

### DIFF
--- a/src/idevicerestore.h
+++ b/src/idevicerestore.h
@@ -96,7 +96,7 @@ int ipsw_extract_filesystem(const char* ipsw, plist_t build_identity, char** fil
 int extract_component(const char* ipsw, const char* path, unsigned char** component_data, unsigned int* component_size);
 int personalize_component(const char *component, const unsigned char* component_data, unsigned int component_size, plist_t tss_response, unsigned char** personalized_component, unsigned int* personalized_component_size);
 
-const char* get_component_name(const char* filename);
+const char* get_component_name(const char* filename, plist_t build_identity, char **ret_value);
 
 #ifdef __cplusplus
 }

--- a/src/img4.c
+++ b/src/img4.c
@@ -164,7 +164,7 @@ int img4_stitch_component(const char* component_name, const unsigned char* compo
 			memcpy((void*)tag, "rdtr", 4);
 		} else if (strcmp(component_name, "RestoreSEP") == 0) {
 			memcpy((void*)tag, "rsep", 4);
-		} else if (strcmp(component_name, "AppleLogo") == 0) {
+		} else if (strcmp(component_name, "RestoreLogo") == 0) {
 			memcpy((void*)tag, "rlgo", 4);
 		}
 	}

--- a/src/img4.c
+++ b/src/img4.c
@@ -166,6 +166,8 @@ int img4_stitch_component(const char* component_name, const unsigned char* compo
 			memcpy((void*)tag, "rsep", 4);
 		} else if (strcmp(component_name, "RestoreLogo") == 0) {
 			memcpy((void*)tag, "rlgo", 4);
+		} else if (strcmp(component_name, "RestoreTrustCache") == 0) {
+			memcpy((void*)tag, "rtsc", 4);
 		}
 	}
 

--- a/src/recovery.c
+++ b/src/recovery.c
@@ -329,7 +329,7 @@ int recovery_send_ibec(struct idevicerestore_client_t* client, plist_t build_ide
 }
 
 int recovery_send_applelogo(struct idevicerestore_client_t* client, plist_t build_identity) {
-	const char* component = "AppleLogo";
+	const char* component = "RestoreLogo";
 	irecv_error_t recovery_error = IRECV_E_SUCCESS;
 
 	info("Sending %s...\n", component);

--- a/src/restore.c
+++ b/src/restore.c
@@ -2436,6 +2436,11 @@ int restore_device(struct idevicerestore_client_t* client, plist_t build_identit
 			err = restore_handle_bb_update_status_msg(restore, message);
 		}
 
+		// hide checkpoint message
+		else if (!strcmp(type, "CheckpointMsg")) {
+			// empty
+		}
+
 		// there might be some other message types i'm not aware of, but I think
 		// at least the "previous error logs" messages usually end up here
 		else {

--- a/src/restore.c
+++ b/src/restore.c
@@ -2314,6 +2314,46 @@ int restore_device(struct idevicerestore_client_t* client, plist_t build_identit
 	}
 	// FIXME: does this have any effect actually?
 	plist_dict_set_item(opts, "UpdateBaseband", plist_new_bool(0));
+
+	plist_t smt = plist_new_dict();
+	plist_dict_set_item(smt, "BBUpdateStatusMsg",		plist_new_bool(0));
+
+	plist_dict_set_item(smt, "CheckpointMsg",			plist_new_bool(1));
+	plist_dict_set_item(smt, "DataRequestMsg",			plist_new_bool(0));
+	plist_dict_set_item(smt, "MsgType",					plist_new_bool(0));
+	plist_dict_set_item(smt, "PreviousRestoreLogMsg",	plist_new_bool(1));
+	plist_dict_set_item(smt, "ProgressMsg",				plist_new_bool(0));
+
+	plist_dict_set_item(smt, "ProvisioningAck",			plist_new_bool(0));
+	plist_dict_set_item(smt, "ProvisioningInfo",		plist_new_bool(0));
+	plist_dict_set_item(smt, "ProvisioningStatusMsg",	plist_new_bool(0));
+	plist_dict_set_item(smt, "ReceivedFinalStatusMsg",	plist_new_bool(0));
+	plist_dict_set_item(smt, "StatusMsg",				plist_new_bool(0));
+
+	plist_dict_set_item(opts, "SupportedMessageTypes",	smt);
+
+	plist_t sep = plist_access_path(build_identity, 3, "Manifest", "SEP", "Info");
+	if (sep) {
+		node = plist_dict_get_item(sep, "RequiredCapacity");
+		if (node && plist_get_node_type(node) == PLIST_STRING) {
+			char* sval = NULL;
+			plist_get_string_val(node, &sval);
+			info("RequiredCapacity: %s\n", sval);
+
+			plist_dict_set_item(opts, "TZ0RequiredCapacity", plist_copy(node));
+			free(sval);
+			sval = NULL;
+		}
+	}
+
+	plist_dict_set_item(opts, "WaitForDeviceConnectionToFinishStateMachine", plist_new_bool(0));
+	plist_dict_set_item(opts, "iTunesVersion",			plist_new_string("iTunes 12.9.0.167"));
+
+	plist_dict_set_item(opts, "FormatForAPFS",	plist_new_bool(1));
+	plist_dict_set_item(opts, "FormatForLwVM",	plist_new_bool(0));
+	plist_dict_set_item(opts, "InstallDiags",	plist_new_bool(0));
+	plist_dict_set_item(opts, "SkipPreflightPersonalization", plist_new_bool(0));
+
 	// FIXME: not required for iOS 5?
 	//plist_dict_set_item(opts, "UserLocale", plist_new_string("en_US"));
 

--- a/src/tss.c
+++ b/src/tss.c
@@ -247,6 +247,51 @@ int tss_parameters_add_from_manifest(plist_t parameters, plist_t build_identity)
 	}
 	node = NULL;
 
+	/* Yonkers,BoardID - Used for Yonkers firmware request */
+	node = plist_dict_get_item(build_identity, "Yonkers,BoardID");
+	if (node) {
+		if (plist_get_node_type(node) == PLIST_STRING) {
+			char *strval = NULL;
+			int intval = 0;
+			plist_get_string_val(node, &strval);
+			sscanf(strval, "%x", &intval);
+			plist_dict_set_item(parameters, "Yonkers,BoardID", plist_new_uint(intval));
+		} else {
+			plist_dict_set_item(parameters, "Yonkers,BoardID", plist_copy(node));
+		}
+	}
+	node = NULL;
+
+	/* Yonkers,ChipID - Used for Yonkers firmware request */
+	node = plist_dict_get_item(build_identity, "Yonkers,ChipID");
+	if (node) {
+		if (plist_get_node_type(node) == PLIST_STRING) {
+			char *strval = NULL;
+			int intval = 0;
+			plist_get_string_val(node, &strval);
+			sscanf(strval, "%x", &intval);
+			plist_dict_set_item(parameters, "Yonkers,ChipID", plist_new_uint(intval));
+		} else {
+			plist_dict_set_item(parameters, "Yonkers,ChipID", plist_copy(node));
+		}
+	}
+	node = NULL;
+
+	/* add Yonkers,PatchEpoch - Used for Yonkers firmware request */
+	node = plist_dict_get_item(build_identity, "Yonkers,PatchEpoch");
+	if (node) {
+		if (plist_get_node_type(node) == PLIST_STRING) {
+			char *strval = NULL;
+			int intval = 0;
+			plist_get_string_val(node, &strval);
+			sscanf(strval, "%x", &intval);
+			plist_dict_set_item(parameters, "Yonkers,PatchEpoch", plist_new_uint(intval));
+		} else {
+			plist_dict_set_item(parameters, "Yonkers,PatchEpoch", plist_copy(node));
+		}
+	}
+	node = NULL;
+
 	/* add build identity manifest dictionary */
 	node = plist_dict_get_item(build_identity, "Manifest");
 	if (!node || plist_get_node_type(node) != PLIST_DICT) {
@@ -726,24 +771,11 @@ int tss_request_add_se_tags(plist_t request, plist_t parameters, plist_t overrid
 	plist_dict_set_item(request, "SE,RootKeyIdentifier", plist_copy(node));
 	node = NULL;
 
-	const char *development_key = NULL;
-	const char *production_key = NULL;
-	if (chip_id == 0x20211) {
-		development_key = "DevelopmentCMAC";
-		production_key = "ProductionCMAC";
-	} else if (chip_id == 0x73) {
-		development_key = "DevelopmentUpdatePayloadHash";
-		production_key = "ProductionUpdatePayloadHash";
-	} else {
-		error("WARNING: Unsupported SE,ChipID 0x%lx. Restore will likely fail.\n", (unsigned long)chip_id);
-	}
-	const char *key_to_remove = development_key;
 	/* 'IsDev' determines whether we have Production or Development */
+	uint8_t is_dev = 0;
 	node = plist_dict_get_item(parameters, "SE,IsDev");
 	if (node && plist_get_node_type(node) == PLIST_BOOLEAN) {
-		uint8_t is_dev = 0;
 		plist_get_bool_val(node, &is_dev);
-		key_to_remove = (is_dev) ? production_key : development_key;
 	}
 
 	/* add SE,* components from build manifest to request */
@@ -774,8 +806,17 @@ int tss_request_add_se_tags(plist_t request, plist_t parameters, plist_t overrid
 		plist_dict_remove_item(tss_entry, "Info");
 
 		/* remove Development or Production key/hash node */
-		if (key_to_remove && plist_dict_get_item(tss_entry, key_to_remove)) {
-			plist_dict_remove_item(tss_entry, key_to_remove);
+		if (is_dev) {
+			if (plist_dict_get_item(tss_entry, "ProductionCMAC"))
+				plist_dict_remove_item(tss_entry, "ProductionCMAC");
+			if (plist_dict_get_item(tss_entry, "ProductionUpdatePayloadHash"))
+				plist_dict_remove_item(tss_entry, "ProductionUpdatePayloadHash");
+		}
+		else {
+			if (plist_dict_get_item(tss_entry, "DevelopmentCMAC"))
+				plist_dict_remove_item(tss_entry, "DevelopmentCMAC");
+			if (plist_dict_get_item(tss_entry, "DevelopmentUpdatePayloadHash"))
+				plist_dict_remove_item(tss_entry, "DevelopmentUpdatePayloadHash");
 		}
 
 		/* add entry to request */
@@ -906,6 +947,51 @@ int tss_request_add_savage_tags(plist_t request, plist_t parameters, plist_t ove
 	}
 	plist_dict_set_item(request, "Savage,ReadECKey", plist_copy(node));
 	node = NULL;
+
+	/* apply overrides */
+	if (overrides) {
+		plist_dict_merge(&request, overrides);
+	}
+
+	return 0;
+}
+
+int tss_request_add_yonkers_tags(plist_t request, plist_t parameters, plist_t overrides)
+{
+	plist_t node = NULL;
+
+	plist_t manifest_node = plist_dict_get_item(parameters, "Manifest");
+	if (!manifest_node || plist_get_node_type(manifest_node) != PLIST_DICT) {
+		error("ERROR: %s: Unable to get restore manifest from parameters\n", __func__);
+		return -1;
+	}
+
+	/* add tags indicating we want to get the Savage,Ticket */
+	plist_dict_set_item(request, "@BBTicket", plist_new_bool(1));
+	plist_dict_set_item(request, "@Yonkers,Ticket", plist_new_bool(1));
+
+	/* add SEP */
+	node = plist_access_path(manifest_node, 2, "SEP", "Digest");
+	if (!node) {
+		error("ERROR: Unable to get SEP digest from manifest\n");
+		return -1;
+	}
+	plist_t dict = plist_new_dict();
+	plist_dict_set_item(dict, "Digest", plist_copy(node));
+	plist_dict_set_item(request, "SEP", dict);
+
+	{
+		static const char *keys[] = {"Yonkers,AllowOfflineBoot", "Yonkers,BoardID", "Yonkers,ChipID", "Yonkers,ECID", "Yonkers,Nonce", "Yonkers,PatchEpoch", "Yonkers,ProductionMode", "Yonkers,ReadECKey", "Yonkers,ReadFWKey", };
+		int i;
+		for (i = 0; i < (int)(sizeof(keys) / sizeof(keys[0])); ++i) {
+			node = plist_dict_get_item(parameters, keys[i]);
+			if (!node) {
+				error("ERROR: %s: Unable to find required %sin parameters\n", __func__, keys[i]);
+			}
+			plist_dict_set_item(request, keys[i], plist_copy(node));
+			node = NULL;
+		}
+	}
 
 	/* apply overrides */
 	if (overrides) {

--- a/src/tss.h
+++ b/src/tss.h
@@ -41,6 +41,7 @@ int tss_request_add_ap_tags(plist_t request, plist_t parameters, plist_t overrid
 int tss_request_add_baseband_tags(plist_t request, plist_t parameters, plist_t overrides);
 int tss_request_add_se_tags(plist_t request, plist_t parameters, plist_t overrides);
 int tss_request_add_savage_tags(plist_t request, plist_t parameters, plist_t overrides);
+int tss_request_add_yonkers_tags(plist_t request, plist_t parameters, plist_t overrides);
 
 int tss_request_add_ap_img4_tags(plist_t request, plist_t parameters);
 int tss_request_add_ap_img3_tags(plist_t request, plist_t parameters);


### PR DESCRIPTION
Seems like a new feature in iOS 12 restore mode, where it prints these messages quite often. Since these are not handled elsewhere, they are printed out to stdout as plist.