### PR TITLE
Common: included <unistd.h> for fix compiling on macOS

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -35,6 +35,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <ctype.h>
+#include <unistd.h>
 
 #ifdef WIN32
 #include <windows.h>


### PR DESCRIPTION
error: use of undeclared identifier 'STDIN_FILENO'
        tcgetattr(STDIN_FILENO, &oldt);