### PR TITLE
Remove .ipsw requirement when extracted IPSW is chosen as source

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -221,6 +221,45 @@ int read_file(const char* filename, void** data, size_t* size) {
 	return 0;
 }
 
+int copy_file(const char* destname, const char* srcname) {
+	FILE *filein, *fileout;
+
+	filein = fopen(srcname, "rb");
+	if (filein == NULL) {
+		error("copy_file: cannot open %s: %s\n", srcname, strerror(errno));
+		return -1;
+	}
+	fileout = fopen(destname, "wb");
+	if (fileout == NULL) {
+		error("copy_file: cannot open %s: %s\n", destname, strerror(errno));
+		return -1;
+	}
+
+	size_t s, d;
+	unsigned char buff[8192];
+	do {
+		s = fread(buff, 1, sizeof buff, filein);
+		if (s) d = fwrite(buff, 1, s, fileout);
+		else   d = 0;
+	} while ((s > 0) && (s == d));
+
+	if (d) {
+		error("copy_file: cannot copy %s: %s\n", srcname, strerror(errno));
+		return -1;
+	}
+
+	if (fclose(fileout)) {
+		error("copy_file: cannot close %s: %s\n", destname, strerror(errno));
+		return -1;
+	}
+	if (fclose(filein)) {
+		error("copy_file: cannot close %s: %s\n", srcname, strerror(errno));
+		return -1;
+	}
+
+	return 0;
+}
+
 void debug_plist(plist_t plist) {
 	uint32_t size = 0;
 	char* data = NULL;

--- a/src/common.h
+++ b/src/common.h
@@ -120,6 +120,7 @@ void debug_plist(plist_t plist);
 void print_progress_bar(double progress);
 int read_file(const char* filename, void** data, size_t* size);
 int write_file(const char* filename, const void* data, size_t size);
+int copy_file(const char* destname, const char* srcname);
 
 char *generate_guid(void);
 

--- a/src/idevicerestore.c
+++ b/src/idevicerestore.c
@@ -1455,12 +1455,16 @@ int main(int argc, char* argv[]) {
 
 	idevicerestore_client = client;
 
+#ifdef _WIN32
+	signal(SIGINT, handle_signal);
+	signal(SIGTERM, handle_signal);
+	signal(SIGABRT, handle_signal);
+#else
 	struct sigaction sa;
 	memset(&sa, 0, sizeof(struct sigaction));
 	sa.sa_handler = handle_signal;
 	sigaction(SIGINT, &sa, NULL);
 	sigaction(SIGTERM, &sa, NULL);
-#ifndef WIN32
 	sigaction(SIGQUIT, &sa, NULL);
 	sa.sa_handler = SIG_IGN;
 	sigaction(SIGPIPE, &sa, NULL);


### PR DESCRIPTION
I noticed when extracted IPSW folder is chosen as source, the baseband is extracted from the .ipsw file anyway. 
This commit add the possibility to take the baseband from the extracted IPSW folder if present.

I think .ipsw file shouldn't be required if extracted IPSW folder contains all files.

