### PR TITLE
configure.ac: fix link against pthread

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -64,6 +64,7 @@ case ${host_os} in
   *)
     AC_MSG_RESULT([yes])
     AX_PTHREAD([], [AC_MSG_ERROR([pthread is required to build $PACKAGE])])
+    AC_CHECK_LIB(pthread, [pthread_kill], [], [AC_MSG_ERROR([pthread with pthread_kill required to build $PACKAGE])])
     ;;
 esac
 AM_CONDITIONAL(WIN32, test x$win32 = xtrue)


### PR DESCRIPTION
Hi,
as Debian maintainer of imobiledevice tools, I've tried to build idevicerestore 1.0.0 for uploading to Debian unstable, and for some reason it failed (while it build successfully in June).

The error is:
```
/bin/bash ../libtool  --tag=CC   --mode=link gcc -Wno-multichar -O2  -I/usr/include/libusb-1.0      -I/usr/include/x86_64-linux-gnu -g -O2 -fdebug-prefix-map=/build/idevicerestore-1.0.0=. -fstack-protector-strong -Wformat -Werror=format-security  -lirecovery-1.0 -limobiledevice-1.0 -lplist-2.0 -lplist-2.0 -lzip -lz -lssl -lcrypto -lcurl -Wl,-z,relro -Wl,-z,now -Wl,--as-needed -Wl,-O1 -Wl,-z,defs -o idevicerestore idevicerestore-idevicerestore.o idevicerestore-common.o idevicerestore-tss.o idevicerestore-fls.o idevicerestore-mbn.o idevicerestore-img3.o idevicerestore-img4.o idevicerestore-ftab.o idevicerestore-ipsw.o idevicerestore-normal.o idevicerestore-dfu.o idevicerestore-recovery.o idevicerestore-restore.o idevicerestore-asr.o idevicerestore-fdr.o idevicerestore-limera1n.o idevicerestore-download.o idevicerestore-locking.o idevicerestore-socket.o idevicerestore-thread.o idevicerestore-jsmn.o idevicerestore-json_plist.o   
libtool: link: gcc -Wno-multichar -O2 -I/usr/include/libusb-1.0 -I/usr/include/x86_64-linux-gnu -g -O2 -fdebug-prefix-map=/build/idevicerestore-1.0.0=. -fstack-protector-strong -Wformat -Werror=format-security -Wl,-z -Wl,relro -Wl,-z -Wl,now -Wl,--as-needed -Wl,-O1 -Wl,-z -Wl,defs -o idevicerestore idevicerestore-idevicerestore.o idevicerestore-common.o idevicerestore-tss.o idevicerestore-fls.o idevicerestore-mbn.o idevicerestore-img3.o idevicerestore-img4.o idevicerestore-ftab.o idevicerestore-ipsw.o idevicerestore-normal.o idevicerestore-dfu.o idevicerestore-recovery.o idevicerestore-restore.o idevicerestore-asr.o idevicerestore-fdr.o idevicerestore-limera1n.o idevicerestore-download.o idevicerestore-locking.o idevicerestore-socket.o idevicerestore-thread.o idevicerestore-jsmn.o idevicerestore-json_plist.o  -lirecovery-1.0 -limobiledevice-1.0 -lplist-2.0 -lzip -lz -lssl -lcrypto -lcurl
/usr/bin/ld: idevicerestore-thread.o: undefined reference to symbol 'pthread_kill@@GLIBC_2.2.5'
/usr/bin/ld: /lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```
And indeed, there is no `-lpthread` flag on the command line and in the generated Makefile `PTHREAD_LIBS` is empty. Maybe something changed on the Debian toolchain, but looking at libimobiledevice configure.ac there's an explicit call to `AC_CHECK_LIB` which is missing in idevicerestore.

Here's a pull request adding that line, which seems to fix the build failure on my side.