### PR TITLE
fix two English typos

### DIFF
--- a/src/fdr.c
+++ b/src/fdr.c
@@ -276,7 +276,7 @@ static int fdr_ctrl_handshake(fdr_client_t fdr)
 
 	device_error = idevice_connection_send(fdr->connection, CTRLCMD, len, &bytes);
 	if (device_error != IDEVICE_E_SUCCESS || bytes != len) {
-		debug("Hmm... lookes like the device doesn't like the newer protocol, using the old one\n");
+		debug("Hmm... looks like the device doesn't like the newer protocol, using the old one\n");
 		ctrlprotoversion = 1;
 		len = sizeof(HELLOCTRLCMD);
 		device_error = idevice_connection_send(fdr->connection, HELLOCTRLCMD, len, &bytes);

--- a/src/tss.c
+++ b/src/tss.c
@@ -1432,7 +1432,7 @@ plist_t tss_request_send(plist_t tss_request, const char* server_url_string) {
 
 		response = malloc(sizeof(tss_response));
 		if (response == NULL) {
-			fprintf(stderr, "Unable to allocate sufficent memory\n");
+			fprintf(stderr, "Unable to allocate sufficient memory\n");
 			return NULL;
 		}
 


### PR DESCRIPTION
Hi, lintian identified two typos in the logs emitted by idevicerestore, here's a PR to fix them.