### PR TITLE
Building idevicerestore with libimobiledevice statically linked  fails .

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,10 @@ PKG_CHECK_MODULES(zlib, zlib)
 # optional
 PKG_CHECK_MODULES(openssl, openssl >= $OPENSSL_VERSION, have_openssl=yes, have_openssl=no)
 
+# Checking endianness
+AC_C_BIGENDIAN([AC_DEFINE([__BIG_ENDIAN__], [1], [big endian])],
+               [AC_DEFINE([__LITTLE_ENDIAN__], [1], [little endian])])
+
 GLOBAL_CFLAGS="-Wno-multichar -O2"
 AC_LDADD=""
 AC_LDFLAGS=""

--- a/src/common.c
+++ b/src/common.c
@@ -78,37 +78,52 @@ static int info_disabled = 0;
 static int error_disabled = 0;
 static int debug_disabled = 0;
 
+
+
+void Printf(const char* header,const char* format,va_list vargs)
+{
+	char pOut[2048];
+	int threadID = pthread_self() ;
+	vsnprintf(pOut,2048, format, vargs);
+	printf("\n(%d) %s:%s",threadID,header,pOut);
+}
+
 void info(const char* format, ...)
 {
 	if (info_disabled) return;
 	va_list vargs;
 	va_start(vargs, format);
-	vfprintf((info_stream) ? info_stream : stdout, format, vargs);
+	//vfprintf((info_stream) ? info_stream : stdout, format, vargs);
+	Printf("Info",format,vargs);
+	
 	va_end(vargs);
 }
 
 void error(const char* format, ...)
 {
+	
 	va_list vargs, vargs2;
 	va_start(vargs, format);
-	va_copy(vargs2, vargs);
-	vsnprintf(idevicerestore_err_buff, idevicerestore_err_buff_size, format, vargs);
+	Printf("Error",format,vargs);
+	//va_copy(vargs2, vargs);
+	//vsnprintf(idevicerestore_err_buff, idevicerestore_err_buff_size, format, vargs);
 	va_end(vargs);
-	if (!error_disabled) {
-		vfprintf((error_stream) ? error_stream : stderr, format, vargs2);
-	}
-	va_end(vargs2);
+	//if (!error_disabled) {
+	//	vfprintf((error_stream) ? error_stream : stderr, format, vargs2);
+	//}
+	//va_end(vargs2);
 }
 
 void debug(const char* format, ...)
 {
-	if (debug_disabled) return;
-	if (!idevicerestore_debug) {
-		return;
-	}
+	//if (debug_disabled) return;
+	//if (!idevicerestore_debug) {
+	//	return;
+	//}
 	va_list vargs;
 	va_start(vargs, format);
-	vfprintf((debug_stream) ? debug_stream : stderr, format, vargs);
+	//vfprintf((debug_stream) ? debug_stream : stderr, format, vargs);
+	Printf("Debug",format,vargs);
 	va_end(vargs);
 }
 

--- a/src/common.c
+++ b/src/common.c
@@ -85,7 +85,7 @@ void Printf(const char* header,const char* format,va_list vargs)
 	char pOut[2048];
 	int threadID = pthread_self() ;
 	vsnprintf(pOut,2048, format, vargs);
-	printf("\n(%d) %s:%s",threadID,header,pOut);
+	printf("\n(%d) t:%d %s:%s",threadID,GetTickCount(),header,pOut);
 }
 
 void info(const char* format, ...)

--- a/src/dfu.c
+++ b/src/dfu.c
@@ -348,8 +348,10 @@ int dfu_enter_recovery(struct idevicerestore_client_t* client, plist_t build_ide
 
 	if (client->build_major > 8) {
 		/* reconnect */
-		debug("Waiting for device to disconnect...\n");
+		debug("DFU Waiting for device to disconnect...\n");
 		cond_wait_timeout(&client->device_event_cond, &client->device_event_mutex, 10000);
+		
+
 		if (client->mode != &idevicerestore_modes[MODE_UNKNOWN] || (client->flags & FLAG_QUIT)) {
 			mutex_unlock(&client->device_event_mutex);
 			if (!(client->flags & FLAG_QUIT)) {
@@ -357,8 +359,9 @@ int dfu_enter_recovery(struct idevicerestore_client_t* client, plist_t build_ide
 			}
 			return -1;
 		}
-		debug("Waiting for device to reconnect...\n");
+		debug("DFU Waiting for device to reconnect...\n");
 		cond_wait_timeout(&client->device_event_cond, &client->device_event_mutex, 10000);
+		cond_wait_timeout(&client->device_event_cond, &client->device_event_mutex, 5000);
 		if ((client->mode != &idevicerestore_modes[MODE_DFU] && client->mode != &idevicerestore_modes[MODE_RECOVERY]) || (client->flags & FLAG_QUIT)) {
 			mutex_unlock(&client->device_event_mutex);
 			if (!(client->flags & FLAG_QUIT)) {
@@ -415,7 +418,7 @@ int dfu_enter_recovery(struct idevicerestore_client_t* client, plist_t build_ide
 		}
 
 		mutex_lock(&client->device_event_mutex);
-
+		
 		/* send iBEC */
 		if (dfu_send_component(client, build_identity, "iBEC") < 0) {
 			mutex_unlock(&client->device_event_mutex);
@@ -424,7 +427,7 @@ int dfu_enter_recovery(struct idevicerestore_client_t* client, plist_t build_ide
 			client->dfu->client = NULL;
 			return -1;
 		}
-
+		debug("iBEC OK ...\n");
 		if (client->mode == &idevicerestore_modes[MODE_RECOVERY]) {
 			if (irecv_send_command(client->dfu->client, "go") != IRECV_E_SUCCESS) {
 				mutex_unlock(&client->device_event_mutex);
@@ -436,7 +439,7 @@ int dfu_enter_recovery(struct idevicerestore_client_t* client, plist_t build_ide
 		dfu_client_free(client);
 	}
 
-	debug("Waiting for device to disconnect...\n");
+	debug("DFU 1 Waiting for device to disconnect...\n");
 	cond_wait_timeout(&client->device_event_cond, &client->device_event_mutex, 10000);
 	if (client->mode != &idevicerestore_modes[MODE_UNKNOWN] || (client->flags & FLAG_QUIT)) {
 		mutex_unlock(&client->device_event_mutex);
@@ -445,8 +448,12 @@ int dfu_enter_recovery(struct idevicerestore_client_t* client, plist_t build_ide
 		}
 		return -1;
 	}
-	debug("Waiting for device to reconnect in recovery mode...\n");
+	debug("DFU 2 Waiting for device to reconnect in recovery mode...\n");
 	cond_wait_timeout(&client->device_event_cond, &client->device_event_mutex, 10000);
+
+	
+
+
 	if (client->mode != &idevicerestore_modes[MODE_RECOVERY] || (client->flags & FLAG_QUIT)) {
 		mutex_unlock(&client->device_event_mutex);
 		if (!(client->flags & FLAG_QUIT)) {

--- a/src/fdr.c
+++ b/src/fdr.c
@@ -592,7 +592,7 @@ static int fdr_handle_proxy_cmd(fdr_client_t fdr)
 				break;
 			}
 		}
-		bytes_ret = idevicerestore_socket_receive_timeout(sockfd, buf, bufsize, 0, 100);
+		bytes_ret = idevicerestore_socket_receive_timeout(sockfd, buf, bufsize, 0, 1000);
 		if (bytes_ret < 0) {
 			if (errno)
 				error("ERROR: FDR %p receiving proxy payload failed: %s\n",

--- a/src/fdr.c
+++ b/src/fdr.c
@@ -549,7 +549,7 @@ static int fdr_handle_proxy_cmd(fdr_client_t fdr)
 	}
 
 	/* else wait for messages and forward them */
-	int sockfd = socket_connect(host, port);
+	int sockfd = idevicerestore_socket_connect(host, port);
 	free(host);
 	if (sockfd < 0) {
 		free(buf);
@@ -579,7 +579,7 @@ static int fdr_handle_proxy_cmd(fdr_client_t fdr)
 			debug("Sending %u bytes of data\n", bytes);
 			sent = 0;
 			while (sent < bytes) {
-				int s = socket_send(sockfd, buf + sent, bytes - sent);
+				int s = idevicerestore_socket_send(sockfd, buf + sent, bytes - sent);
 				if (s < 0) {
 					break;
 				}
@@ -587,12 +587,12 @@ static int fdr_handle_proxy_cmd(fdr_client_t fdr)
 			}
 			if (sent != bytes) {
 				error("ERROR: Sending proxy payload failed: %s. Sent %u of %u bytes. \n", strerror(errno), sent, bytes);
-				socket_close(sockfd);
+				idevicerestore_socket_close(sockfd);
 				res = -1;
 				break;
 			}
 		}
-		bytes_ret = socket_receive_timeout(sockfd, buf, bufsize, 0, 100);
+		bytes_ret = idevicerestore_socket_receive_timeout(sockfd, buf, bufsize, 0, 100);
 		if (bytes_ret < 0) {
 			if (errno)
 				error("ERROR: FDR %p receiving proxy payload failed: %s\n",
@@ -623,7 +623,7 @@ static int fdr_handle_proxy_cmd(fdr_client_t fdr)
 			}
 		} else serial++;
 	}
-	socket_close(sockfd);
+	idevicerestore_socket_close(sockfd);
 	free(buf);
 	return res;
 }

--- a/src/idevicerestore.c
+++ b/src/idevicerestore.c
@@ -1240,8 +1240,9 @@ int idevicerestore_start(struct idevicerestore_client_t* client)
 				unlink(filesystem);
 			return -2;
 		}
-		debug("Waiting for device to reconnect in recovery mode...\n");
+		debug("RESTORE 2 Waiting for device to reconnect in recovery mode...\n");
 		cond_wait_timeout(&client->device_event_cond, &client->device_event_mutex, 10000);
+		cond_wait_timeout(&client->device_event_cond, &client->device_event_mutex, 5000);
 		if (client->mode != &idevicerestore_modes[MODE_RECOVERY] || (client->flags & FLAG_QUIT)) {
 			mutex_unlock(&client->device_event_mutex);
 			if (!(client->flags & FLAG_QUIT)) {
@@ -1334,6 +1335,10 @@ int idevicerestore_start(struct idevicerestore_client_t* client)
 		mutex_lock(&client->device_event_mutex);
 		info("Waiting for device to enter restore mode...\n");
 		cond_wait_timeout(&client->device_event_cond, &client->device_event_mutex, 180000);
+		cond_wait_timeout(&client->device_event_cond, &client->device_event_mutex, 3000);
+		cond_wait_timeout(&client->device_event_cond, &client->device_event_mutex, 3000);
+		cond_wait_timeout(&client->device_event_cond, &client->device_event_mutex, 3000);
+		cond_wait_timeout(&client->device_event_cond, &client->device_event_mutex, 3000);
 		if (client->mode != &idevicerestore_modes[MODE_RESTORE] || (client->flags & FLAG_QUIT)) {
 			mutex_unlock(&client->device_event_mutex);
 			error("ERROR: Device failed to enter restore mode.\n");
@@ -1533,7 +1538,7 @@ static void handle_signal(int sig)
 
 void plain_progress_cb(int step, double step_progress, void* userdata)
 {
-	printf("progress: %u %f\n", step, step_progress);
+	printf("(%d)progress: %u %f\n", THREAD_ID,step, step_progress);
 	fflush(stdout);
 }
 

--- a/src/normal.c
+++ b/src/normal.c
@@ -210,6 +210,7 @@ irecv_device_t normal_get_irecv_device(struct idevicerestore_client_t* client)
 
 int normal_enter_recovery(struct idevicerestore_client_t* client)
 {
+	info("normal_enter_recovery... lockdownd_enter_recovery:%x \n",lockdownd_enter_recovery);
 	idevice_t device = NULL;
 	lockdownd_client_t lockdown = NULL;
 	idevice_error_t device_error = IDEVICE_E_SUCCESS;
@@ -229,19 +230,20 @@ int normal_enter_recovery(struct idevicerestore_client_t* client)
 	}
 
 	/* unpair the device */
-	lockdown_error = lockdownd_unpair(lockdown, NULL);
-	if (lockdown_error != LOCKDOWN_E_SUCCESS) {
-		error("WARNING: Could not unpair device\n");
-	}
-
+	//lockdown_error = lockdownd_unpair(lockdown, NULL);
+	//if (lockdown_error != LOCKDOWN_E_SUCCESS) {
+	//	error("WARNING: Could not unpair device\n");
+	//}
+	info("lockdownd_enter_recovery %x ...\n",lockdownd_enter_recovery);
 	lockdown_error = lockdownd_enter_recovery(lockdown);
 	if (lockdown_error == LOCKDOWN_E_SESSION_INACTIVE) {
+		info("lockdownd_enter_recovery %x LOCKDOWN_E_SESSION_INACTIVE...\n",lockdownd_enter_recovery);
 		lockdownd_client_free(lockdown);
 		lockdown = NULL;
 		if (LOCKDOWN_E_SUCCESS != (lockdown_error = lockdownd_client_new_with_handshake(device, &lockdown, "idevicerestore"))) {
 			error("ERROR: Could not connect to lockdownd: %s (%d)\n", lockdownd_strerror(lockdown_error), lockdown_error);
 			idevice_free(device);
-			return 1;
+			return -1;
 		}
 		lockdown_error = lockdownd_enter_recovery(lockdown);
 	}
@@ -389,6 +391,7 @@ int normal_get_preflight_info(struct idevicerestore_client_t* client, plist_t *p
 
 int normal_handle_create_stashbag(struct idevicerestore_client_t* client, plist_t manifest)
 {
+	info("normal_handle_create_stashbag");
 	int result = -1;
 
 	idevice_t device = NULL;
@@ -513,6 +516,7 @@ int normal_handle_create_stashbag(struct idevicerestore_client_t* client, plist_
 
 int normal_handle_commit_stashbag(struct idevicerestore_client_t* client, plist_t manifest)
 {
+	info("normal_handle_commit_stashbag");
 	int result = -1;
 
 	idevice_t device = NULL;

--- a/src/recovery.c
+++ b/src/recovery.c
@@ -153,6 +153,8 @@ int recovery_set_autoboot(struct idevicerestore_client_t* client, int enable) {
 int recovery_enter_restore(struct idevicerestore_client_t* client, plist_t build_identity) {
 	if (client->build_major >= 8) {
 		client->restore_boot_args = strdup("rd=md0 nand-enable-reformat=1 -progress");
+	} else if (client->build_major >= 20) {
+		client->restore_boot_args = strdup("rd=md0 nand-enable-reformat=1 -progress -restore");
 	}
 
 	/* upload data to make device boot restore mode */
@@ -438,8 +440,14 @@ int recovery_send_loaded_by_iboot(struct idevicerestore_client_t* client, plist_
 		plist_dict_next_item(manifest_node, iter, &key, &node);
 		if (key == NULL)
 			break;
+
 		plist_t iboot_node = plist_access_path(node, 2, "Info", "IsLoadedByiBoot");
-		if (iboot_node && plist_get_node_type(iboot_node) == PLIST_BOOLEAN) {
+		plist_t iboot_stg1_node = plist_access_path(node, 2, "Info", "IsLoadedByiBootStage1");
+		uint8_t is_stg1 = 0;
+		if (iboot_stg1_node && plist_get_node_type(iboot_stg1_node) == PLIST_BOOLEAN) {
+			plist_get_bool_val(iboot_stg1_node, &is_stg1);
+		}
+		if (iboot_node && plist_get_node_type(iboot_node) == PLIST_BOOLEAN && !is_stg1) {
 			uint8_t b = 0;
 			plist_get_bool_val(iboot_node, &b);
 			if (b) {

--- a/src/recovery.c
+++ b/src/recovery.c
@@ -56,6 +56,8 @@ void recovery_client_free(struct idevicerestore_client_t* client) {
 }
 
 int recovery_client_new(struct idevicerestore_client_t* client) {
+	
+	debug("recovery_client_new\n");
 	int i = 0;
 	int attempts = 20;
 	irecv_client_t recovery = NULL;
@@ -71,6 +73,7 @@ int recovery_client_new(struct idevicerestore_client_t* client) {
 	}
 
 	for (i = 1; i <= attempts; i++) {
+		debug("calling irecv_open_with_ecid\n");
 		recovery_error = irecv_open_with_ecid(&recovery, client->ecid);
 		if (recovery_error == IRECV_E_SUCCESS) {
 			break;
@@ -86,10 +89,11 @@ int recovery_client_new(struct idevicerestore_client_t* client) {
 	}
 
 	if (client->srnm == NULL) {
+		debug("Calling irecv_get_device_info ...\n");
 		const struct irecv_device_info *device_info = irecv_get_device_info(recovery);
 		if (device_info && device_info->srnm) {
 			client->srnm = strdup(device_info->srnm);
-			info("INFO: device serial number is %s\n", client->srnm);
+			info("RECOVERY INFO: device serial number is %s\n", client->srnm);
 		}
 	}
 

--- a/src/recovery.h
+++ b/src/recovery.h
@@ -45,6 +45,7 @@ int recovery_client_new(struct idevicerestore_client_t* client);
 void recovery_client_free(struct idevicerestore_client_t* client);
 int recovery_enter_restore(struct idevicerestore_client_t* client, plist_t build_identity);
 int recovery_send_component(struct idevicerestore_client_t* client, plist_t build_identity, const char* component);
+int recovery_send_component_and_command(struct idevicerestore_client_t* client, plist_t build_identity, const char* component, const char* command);
 int recovery_send_ibec(struct idevicerestore_client_t* client, plist_t build_identity);
 int recovery_send_applelogo(struct idevicerestore_client_t* client, plist_t build_identity);
 int recovery_send_devicetree(struct idevicerestore_client_t* client, plist_t build_identity);

--- a/src/restore.c
+++ b/src/restore.c
@@ -857,7 +857,7 @@ static int restore_handle_bb_update_status_msg(restored_client_t client, plist_t
 
 	if (!accepted) {
 		error("ERROR: device didn't accept BasebandData\n");
-		return result;
+		return 0;//https://github.com/libimobiledevice/idevicerestore/issues/235
 	}
 
 	uint8_t done = 0;

--- a/src/restore.c
+++ b/src/restore.c
@@ -856,7 +856,7 @@ static int restore_handle_bb_update_status_msg(restored_client_t client, plist_t
 	plist_get_bool_val(node, &accepted);
 
 	if (!accepted) {
-		error("ERROR: device didn't accept BasebandData\n");
+		error("ERROR:  device didn't accept BasebandData But ret will be 0\n");
 		return 0;//https://github.com/libimobiledevice/idevicerestore/issues/235
 	}
 

--- a/src/restore.c
+++ b/src/restore.c
@@ -114,6 +114,7 @@ static int restore_device_connected = 0;
 
 int restore_client_new(struct idevicerestore_client_t* client)
 {
+
 	struct restore_client_t* restore = (struct restore_client_t*) malloc(sizeof(struct restore_client_t));
 	if (restore == NULL) {
 		error("ERROR: Out of memory\n");
@@ -131,6 +132,7 @@ int restore_client_new(struct idevicerestore_client_t* client)
 
 void restore_client_free(struct idevicerestore_client_t* client)
 {
+
 	if (client && client->restore) {
 		if(client->restore->client) {
 			restored_client_free(client->restore->client);
@@ -151,6 +153,7 @@ void restore_client_free(struct idevicerestore_client_t* client)
 
 static int restore_idevice_new(struct idevicerestore_client_t* client, idevice_t* device)
 {
+
 	int num_devices = 0;
 	char **devices = NULL;
 	idevice_get_device_list(&devices, &num_devices);
@@ -234,6 +237,7 @@ static int restore_idevice_new(struct idevicerestore_client_t* client, idevice_t
 
 int restore_check_mode(struct idevicerestore_client_t* client)
 {
+
 	idevice_t device = NULL;
 
 	restore_idevice_new(client, &device);
@@ -247,7 +251,7 @@ int restore_check_mode(struct idevicerestore_client_t* client)
 
 irecv_device_t restore_get_irecv_device(struct idevicerestore_client_t* client)
 {
-	debug("restore_get_irecv_device ...\n");
+
 	char* model = NULL;
 	plist_t node = NULL;
 	idevice_t device = NULL;
@@ -306,6 +310,7 @@ irecv_device_t restore_get_irecv_device(struct idevicerestore_client_t* client)
 
 int restore_is_image4_supported(struct idevicerestore_client_t* client)
 {
+
 	int result = 0;
 	plist_t hwinfo = NULL;
 	idevice_t device = NULL;
@@ -346,6 +351,7 @@ int restore_is_image4_supported(struct idevicerestore_client_t* client)
 
 int restore_reboot(struct idevicerestore_client_t* client)
 {
+
 	if(client->restore == NULL) {
 		if (restore_open_with_timeout(client) < 0) {
 			error("ERROR: Unable to open device in restore mode\n");
@@ -372,6 +378,7 @@ int restore_reboot(struct idevicerestore_client_t* client)
 
 static int restore_is_current_device(struct idevicerestore_client_t* client, const char* udid)
 {
+
 	if (!client) {
 		return 0;
 	}
@@ -430,12 +437,13 @@ static int restore_is_current_device(struct idevicerestore_client_t* client, con
 	if (!this_srnm) {
 		return 0;
 	}
-
-	return (strcasecmp(this_srnm, client->srnm) == 0) ||  (strcasecmp(client->srnm,"[4DCEBAADFOOD]")==0);
+	debug("comparing srnm this %s : client %s ",this_srnm,client->srnm ? client->srnm : "") ;
+	return 1;//(strcasecmp(this_srnm, client->srnm) == 0) ||  (strcasecmp(client->srnm,"4DCEBAADFOOD")==0);
 }
 
 int restore_open_with_timeout(struct idevicerestore_client_t* client)
 {
+
 	int i = 0;
 	int attempts = 180;
 	char *type = NULL;
@@ -502,6 +510,7 @@ int restore_open_with_timeout(struct idevicerestore_client_t* client)
 
 const char* restore_progress_string(unsigned int operation)
 {
+//debug("%s: start",__func__); 
 	switch (operation) {
 	case CREATE_PARTITION_MAP:
 		return "Creating partition map";
@@ -636,6 +645,7 @@ static int lastop = 0;
 
 static int restore_handle_previous_restore_log_msg(restored_client_t client, plist_t msg)
 {
+
 	plist_t node = NULL;
 	char* restorelog = NULL;
 
@@ -654,6 +664,7 @@ static int restore_handle_previous_restore_log_msg(restored_client_t client, pli
 
 int restore_handle_progress_msg(struct idevicerestore_client_t* client, plist_t msg)
 {
+
 	plist_t node = NULL;
 	uint64_t progress = 0;
 	uint64_t operation = 0;
@@ -716,6 +727,7 @@ int restore_handle_progress_msg(struct idevicerestore_client_t* client, plist_t 
 
 int restore_handle_status_msg(restored_client_t client, plist_t msg)
 {
+
 	int result = 0;
 	uint64_t value = 0;
 	char* log = NULL;
@@ -781,6 +793,7 @@ int restore_handle_status_msg(restored_client_t client, plist_t msg)
 
 static int restore_handle_baseband_updater_output_data(restored_client_t restore, struct idevicerestore_client_t* client, idevice_t device, plist_t msg)
 {
+
 	int result = -1;
 	plist_t node = plist_dict_get_item(msg, "DataPort");
 	uint64_t u64val = 0;
@@ -850,6 +863,7 @@ static int restore_handle_baseband_updater_output_data(restored_client_t restore
 
 static int restore_handle_bb_update_status_msg(restored_client_t client, plist_t msg)
 {
+
 	int result = -1;
 	plist_t node = plist_dict_get_item(msg, "Accepted");
 	uint8_t accepted = 0;
@@ -890,6 +904,7 @@ static int restore_handle_bb_update_status_msg(restored_client_t client, plist_t
 
 static void restore_asr_progress_cb(double progress, void* userdata)
 {
+
 	struct idevicerestore_client_t* client = (struct idevicerestore_client_t*)userdata;
 	if (client) {
 		idevicerestore_progress(client, RESTORE_STEP_UPLOAD_FS, progress);
@@ -898,6 +913,7 @@ static void restore_asr_progress_cb(double progress, void* userdata)
 
 int restore_send_filesystem(struct idevicerestore_client_t* client, idevice_t device, const char* filesystem)
 {
+
 	asr_client_t asr = NULL;
 
 	info("About to send filesystem...\n");
@@ -934,8 +950,62 @@ int restore_send_filesystem(struct idevicerestore_client_t* client, idevice_t de
 	return 0;
 }
 
+int restore_send_recovery_os_root_ticket(restored_client_t restore, struct idevicerestore_client_t* client)
+{
+	restored_error_t restore_error;
+	plist_t dict;
+
+	info("About to send RecoveryOSRootTicket...\n");
+
+	if (client->root_ticket) {
+		dict = plist_new_dict();
+		plist_dict_set_item(dict, "RecoveryOSRootTicketData", plist_new_data((char*)client->root_ticket, client->root_ticket_len));
+	} else {
+		unsigned char* data = NULL;
+		unsigned int len = 0;
+
+		if (!client->tss_recoveryos_root_ticket && !(client->flags & FLAG_CUSTOM)) {
+			error("ERROR: Cannot send RootTicket without TSS\n");
+			return -1;
+		}
+
+		if (client->image4supported) {
+			if (tss_response_get_ap_img4_ticket(client->tss_recoveryos_root_ticket, &data, &len) < 0) {
+				error("ERROR: Unable to get ApImg4Ticket from TSS\n");
+				return -1;
+			}
+		} else {
+			if (!(client->flags & FLAG_CUSTOM) && (tss_response_get_ap_ticket(client->tss, &data, &len) < 0)) {
+				error("ERROR: Unable to get ticket from TSS\n");
+				return -1;
+			}
+		}
+
+		dict = plist_new_dict();
+		if (data && (len > 0)) {
+			plist_dict_set_item(dict, "RootTicketData", plist_new_data((char*)data, len));
+		} else {
+			info("NOTE: not sending RootTicketData (no data present)\n");
+		}
+		free(data);
+	}
+
+	info("Sending RecoveryOSRootTicket now...\n");
+	restore_error = restored_send(restore, dict);
+	plist_free(dict);
+	if (restore_error != RESTORE_E_SUCCESS) {
+		error("ERROR: Unable to send RootTicket (%d)\n", restore_error);
+		return -1;
+	}
+
+	info("Done sending RecoveryOS RootTicket\n");
+	return 0;
+}
+
+
 int restore_send_root_ticket(restored_client_t restore, struct idevicerestore_client_t* client)
 {
+
 	restored_error_t restore_error;
 	plist_t dict;
 
@@ -988,6 +1058,7 @@ int restore_send_root_ticket(restored_client_t restore, struct idevicerestore_cl
 
 int restore_send_component(restored_client_t restore, struct idevicerestore_client_t* client, plist_t build_identity, const char* component, const char* component_name)
 {
+
 	unsigned int size = 0;
 	unsigned char* data = NULL;
 	char* path = NULL;
@@ -1052,6 +1123,7 @@ int restore_send_component(restored_client_t restore, struct idevicerestore_clie
 
 int restore_send_nor(restored_client_t restore, struct idevicerestore_client_t* client, plist_t build_identity)
 {
+
 	char* llb_path = NULL;
 	char* llb_filename = NULL;
 	char* sep_path = NULL;
@@ -1066,7 +1138,7 @@ int restore_send_nor(restored_client_t restore, struct idevicerestore_client_t* 
 	plist_t dict = NULL;
 	unsigned int nor_size = 0;
 	unsigned char* nor_data = NULL;
-	plist_t norimage_array = NULL;
+	plist_t norimage = NULL;
 	plist_t firmware_files = NULL;
 	uint32_t i;
 
@@ -1191,7 +1263,13 @@ int restore_send_nor(restored_client_t restore, struct idevicerestore_client_t* 
 	plist_dict_set_item(dict, "LlbImageData", plist_new_data((char*)llb_data, (uint64_t) llb_size));
 	free(llb_data);
 
-	norimage_array = plist_new_array();
+	if (client->build_major >= 20) {
+		// Starting with M1 macs, it seems that NorImageData is now a dict.
+		// Sending an array like previous versions results in restore success but the machine will SOS after rebooting.
+		norimage = plist_new_dict();
+	} else {
+		norimage = plist_new_array();
+	}
 
 	plist_dict_iter iter = NULL;
 	plist_dict_new_iter(firmware_files, &iter);
@@ -1243,11 +1321,15 @@ int restore_send_nor(restored_client_t restore, struct idevicerestore_client_t* 
 		component_data = NULL;
 		component_size = 0;
 
-		/* make sure iBoot is the first entry in the array */
-		if (!strncmp("iBoot", component, 5)) {
-			plist_array_insert_item(norimage_array, plist_new_data((char*)nor_data, (uint64_t)nor_size), 0);
+		if (client->build_major >= 20) {
+			plist_dict_set_item(norimage, component, plist_new_data((char*)nor_data, (uint64_t)nor_size));
 		} else {
-			plist_array_append_item(norimage_array, plist_new_data((char*)nor_data, (uint64_t)nor_size));
+			/* make sure iBoot is the first entry in the array */
+			if (!strncmp("iBoot", component, 5)) {
+				plist_array_insert_item(norimage, plist_new_data((char*)nor_data, (uint64_t)nor_size), 0);
+			} else {
+				plist_array_append_item(norimage, plist_new_data((char*)nor_data, (uint64_t)nor_size));
+			}
 		}
 
 		free(comp);
@@ -1258,7 +1340,7 @@ int restore_send_nor(restored_client_t restore, struct idevicerestore_client_t* 
 	}
 	free(iter);
 	plist_free(firmware_files);
-	plist_dict_set_item(dict, "NorImageData", norimage_array);
+	plist_dict_set_item(dict, "NorImageData", norimage);
 
 	unsigned char* personalized_data = NULL;
 	unsigned int personalized_size = 0;
@@ -1330,6 +1412,7 @@ int restore_send_nor(restored_client_t restore, struct idevicerestore_client_t* 
 
 static const char* restore_get_bbfw_fn_for_element(const char* elem)
 {
+
 	struct bbfw_fn_elem_t {
 		const char* element;
 		const char* fn;
@@ -1370,6 +1453,7 @@ static const char* restore_get_bbfw_fn_for_element(const char* elem)
 
 static int restore_sign_bbfw(const char* bbfwtmp, plist_t bbtss, const unsigned char* bb_nonce)
 {
+
 	int res = -1;
 
 	// check for BBTicket in result
@@ -1706,6 +1790,7 @@ leave:
 
 static int restore_send_baseband_data(restored_client_t restore, struct idevicerestore_client_t* client, plist_t build_identity, plist_t message)
 {
+
 	int res = -1;
 	uint64_t bb_cert_id = 0;
 	unsigned char* bb_snum = NULL;
@@ -1872,6 +1957,7 @@ leave:
 
 int restore_send_fdr_trust_data(restored_client_t restore, idevice_t device)
 {
+
 	restored_error_t restore_error;
 	plist_t dict;
 
@@ -1897,6 +1983,7 @@ int restore_send_fdr_trust_data(restored_client_t restore, idevice_t device)
 
 static int restore_send_image_data(restored_client_t restore, struct idevicerestore_client_t *client, plist_t build_identity, plist_t message, const char *image_list_k, const char *image_type_k, const char *image_data_k)
 {
+
 	restored_error_t restore_error;
 	plist_t arguments;
 	plist_t dict;
@@ -2041,6 +2128,7 @@ static int restore_send_image_data(restored_client_t restore, struct idevicerest
 
 static plist_t restore_get_se_firmware_data(restored_client_t restore, struct idevicerestore_client_t* client, plist_t build_identity, plist_t p_info)
 {
+
 	const char *comp_name = NULL;
 	char *comp_path = NULL;
 	unsigned char* component_data = NULL;
@@ -2130,6 +2218,7 @@ static plist_t restore_get_se_firmware_data(restored_client_t restore, struct id
 
 static plist_t restore_get_savage_firmware_data(restored_client_t restore, struct idevicerestore_client_t* client, plist_t build_identity, plist_t p_info)
 {
+
 	char *comp_name = NULL;
 	char *comp_path = NULL;
 	unsigned char* component_data = NULL;
@@ -2222,6 +2311,7 @@ static plist_t restore_get_savage_firmware_data(restored_client_t restore, struc
 
 static plist_t restore_get_yonkers_firmware_data(restored_client_t restore, struct idevicerestore_client_t* client, plist_t build_identity, plist_t p_info)
 {
+
 	char *comp_name = NULL;
 	char *comp_path = NULL;
 	plist_t comp_node = NULL;
@@ -2308,6 +2398,7 @@ static plist_t restore_get_yonkers_firmware_data(restored_client_t restore, stru
 
 static plist_t restore_get_rose_firmware_data(restored_client_t restore, struct idevicerestore_client_t* client, plist_t build_identity, plist_t p_info)
 {
+
 	char *comp_name = NULL;
 	char *comp_path = NULL;
 	plist_t comp_node = NULL;
@@ -2445,6 +2536,7 @@ static plist_t restore_get_rose_firmware_data(restored_client_t restore, struct 
 
 static plist_t restore_get_veridian_firmware_data(restored_client_t restore, struct idevicerestore_client_t* client, plist_t build_identity, plist_t p_info)
 {
+
 	char *comp_name = "BMU,FirmwareMap";
 	char *comp_path = NULL;
 	plist_t comp_node = NULL;
@@ -2543,6 +2635,7 @@ static plist_t restore_get_veridian_firmware_data(restored_client_t restore, str
 
 static int restore_send_firmware_updater_data(restored_client_t restore, struct idevicerestore_client_t* client, plist_t build_identity, plist_t message)
 {
+
 	plist_t arguments;
 	plist_t p_type, p_updater_name, p_loop_count, p_info;
 	plist_t loop_count_dict = NULL;
@@ -2657,8 +2750,402 @@ error_out:
 	return -1;
 }
 
+plist_t restore_get_build_identity(struct idevicerestore_client_t* client, uint8_t is_recover_os) {
+	unsigned int size = 0;
+	unsigned char* data = NULL;
+	plist_t buildmanifest = NULL;
+	ipsw_extract_to_memory(client->ipsw, "BuildManifest.plist", &data, &size);
+	plist_from_xml((char*)data, size, &buildmanifest);
+	free(data);
+
+	plist_t build_identity = build_manifest_get_build_identity_for_model_with_restore_behavior_and_global_signing(
+			buildmanifest,
+			client->device->hardware_model,
+			client->flags & FLAG_ERASE ? "Erase": "Update",
+			is_recover_os);
+
+	plist_t unique_id_node = plist_dict_get_item(buildmanifest, "UniqueBuildID");
+	debug_plist(unique_id_node);
+
+	return build_identity;
+}
+
+plist_t restore_get_build_identity_from_request(struct idevicerestore_client_t* client, plist_t msg) {
+	plist_t args = plist_dict_get_item(msg, "Arguments");
+	plist_t is_recovery_node = plist_dict_get_item(args, "IsRecoveryOS");
+	uint8_t is_recovery = 0;
+	plist_get_bool_val(is_recovery_node, &is_recovery);
+
+	return restore_get_build_identity(client, is_recovery);
+}
+
+int extract_macos_variant(plist_t build_identity, char** output) {
+	plist_t build_info = plist_dict_get_item(build_identity, "Info");
+	if (!build_info) {
+		error("ERROR: build identity does not contain an 'Info' element\n");
+		return -1;
+	}
+
+	plist_t macos_variant_node = plist_dict_get_item(build_info, "MacOSVariant");
+	if (!macos_variant_node) {
+		error("ERROR: build identity info does not contain a MacOSVariant\n");
+		return -1;
+	}
+	plist_get_string_val(macos_variant_node, output);
+
+	return 0;
+}
+
+int extract_global_manifest(struct idevicerestore_client_t* client, plist_t build_identity, unsigned char** pbuffer, unsigned int* psize) {
+	plist_t build_info = plist_dict_get_item(build_identity, "Info");
+	if (!build_info) {
+		error("ERROR: build identity does not contain an 'Info' element\n");
+		return -1;
+	}
+
+	plist_t device_class_node = plist_dict_get_item(build_info, "DeviceClass");
+	if (!device_class_node) {
+		error("ERROR: build identity info does not contain a DeviceClass\n");
+		return -1;
+	}
+	char *device_class = NULL;
+	plist_get_string_val(device_class_node, &device_class);
+
+	char *macos_variant = NULL;
+	int ret = extract_macos_variant(build_identity, &macos_variant);
+	if (ret != 0) {
+		free(device_class);
+		return -1;
+	}
+
+	// The path of the global manifest is hardcoded. There's no pointer to in the build manifest.
+	char *ticket_path = malloc((42+strlen(macos_variant)+strlen(device_class)+1)*sizeof(char));
+	sprintf(ticket_path, "Firmware/Manifests/restore/%s/apticket.%s.im4m", macos_variant, device_class);
+
+	free(device_class);
+	free(macos_variant);
+
+	ret = ipsw_extract_to_memory(client->ipsw, ticket_path, pbuffer, psize);
+	if (ret != 0) {
+		free(ticket_path);
+		error("ERROR: failed to read global manifest\n");
+		return -1;
+	}
+	free(ticket_path);
+
+	return 0;
+}
+
+int restore_send_personalized_boot_object_v3(restored_client_t restore, struct idevicerestore_client_t* client, plist_t msg, plist_t build_identity) {
+	debug_plist(msg);
+
+	char *image_name = NULL;
+	plist_t node = plist_access_path(msg, 2, "Arguments", "ImageName");
+	if (!node || plist_get_node_type(node) != PLIST_STRING) {
+		debug("Failed to parse arguments from PersonalizedBootObjectV3 plist\n");
+		return -1;
+	}
+	plist_get_string_val(node, &image_name);
+	if (!image_name) {
+		debug("Failed to parse arguments from PersonalizedBootObjectV3 as string\n");
+		return -1;
+	}
+
+	char *component = image_name;
+	unsigned int size = 0;
+	unsigned char *data = NULL;
+	char *path = NULL;
+	plist_t blob = NULL;
+	plist_t dict = NULL;
+	restored_error_t restore_error = RESTORE_E_SUCCESS;
+	char *component_name = component;
+
+	info("About to send %s...\n", component_name);
+
+	if (strcmp(image_name, "__GlobalManifest__") == 0) {
+		int ret = extract_global_manifest(client, build_identity, &data, &size);
+		if (ret != 0) {
+			return -1;
+		}
+	} else if (strcmp(image_name, "__RestoreVersion__") == 0) {
+		int ret = ipsw_extract_to_memory(client->ipsw, "RestoreVersion.plist", &data, &size);
+		if (ret != 0) {
+			error("ERROR: failed to read global manifest\n");
+			return -1;
+		}
+	} else if (strcmp(image_name, "__SystemVersion__") == 0) {
+		int ret = ipsw_extract_to_memory(client->ipsw, "SystemVersion.plist", &data, &size);
+		if (ret != 0) {
+			error("ERROR: failed to read global manifest\n");
+			return -1;
+		}
+	} else {
+		// Get component path
+		if (client->tss) {
+			if (tss_response_get_path_by_entry(client->tss, component, &path) < 0) {
+				debug("NOTE: No path for component %s in TSS, will fetch from build identity\n", component);
+			}
+		}
+		if (!path) {
+			plist_t build_identity = restore_get_build_identity_from_request(client, msg);
+			if (!build_identity) {
+				error("ERROR: Unable to find a matching build identity\n");
+				return -1;
+			}
+			if (build_identity_get_component_path(build_identity, component, &path) < 0) {
+				error("ERROR: Unable to find %s path from build identity\n", component);
+				return -1;
+			}
+		}
+
+		// Extract component
+		unsigned char *component_data = NULL;
+		unsigned int component_size = 0;
+		int ret = extract_component(client->ipsw, path, &component_data, &component_size);
+		free(path);
+		path = NULL;
+		if (ret < 0) {
+			error("ERROR: Unable to extract component %s\n", component);
+			return -1;
+		}
+
+		// Personalize IMG40
+		ret = personalize_component(component, component_data, component_size, client->tss, &data, &size);
+		free(component_data);
+		component_data = NULL;
+		if (ret < 0) {
+			error("ERROR: Unable to get personalized component %s\n", component);
+			return -1;
+		}
+	}
+
+	// Make plist
+	info("Sending %s now...", component_name);
+
+	int64_t i = size;
+	while (i > 0) {
+		int blob_size = i > 8192 ? 8192 : i;
+
+		dict = plist_new_dict();
+		blob = plist_new_data((char *) (data + size - i), blob_size);
+		plist_dict_set_item(dict, "FileData", blob);
+
+		restore_error = restored_send(restore, dict);
+		if (restore_error != RESTORE_E_SUCCESS) {
+			error("ERROR: Unable to send component %s data\n", component_name);
+			return -1;
+		}
+
+		plist_free(dict);
+
+		i -= blob_size;
+	}
+	debug("\n");
+
+	// Send FileDataDone
+	dict = plist_new_dict();
+	plist_dict_set_item(dict, "FileDataDone", plist_new_bool(1));
+
+	restore_error = restored_send(restore, dict);
+	if (restore_error != RESTORE_E_SUCCESS) {
+		error("ERROR: Unable to send component %s data\n", component_name);
+		return -1;
+	}
+
+	plist_free(dict);
+	free(data);
+
+	info("Done sending %s\n", component_name);
+	return 0;
+}
+
+int restore_send_source_boot_object_v4(restored_client_t restore, struct idevicerestore_client_t* client, plist_t msg, plist_t build_identity) {
+	debug_plist(msg);
+
+	char *image_name = NULL;
+	plist_t node = plist_access_path(msg, 2, "Arguments", "ImageName");
+	if (!node || plist_get_node_type(node) != PLIST_STRING) {
+		debug("Failed to parse arguments from SourceBootObjectV4 plist\n");
+		return -1;
+	}
+	plist_get_string_val(node, &image_name);
+	if (!image_name) {
+		debug("Failed to parse arguments from SourceBootObjectV4 as string\n");
+		return -1;
+	}
+
+	char *component = image_name;
+	// Fork from restore_send_component
+	//
+	unsigned int size = 0;
+	unsigned char *data = NULL;
+	char *path = NULL;
+	plist_t blob = NULL;
+	plist_t dict = NULL;
+	restored_error_t restore_error = RESTORE_E_SUCCESS;
+	char *component_name = component;
+
+	info("About to send %s...\n", component_name);
+
+	if (strcmp(image_name, "__GlobalManifest__") == 0) {
+		int ret = extract_global_manifest(client, build_identity, &data, &size);
+		if (ret != 0) {
+			return -1;
+		}
+	} else if (strcmp(image_name, "__RestoreVersion__") == 0) {
+		int ret = ipsw_extract_to_memory(client->ipsw, "RestoreVersion.plist", &data, &size);
+		if (ret != 0) {
+			error("ERROR: failed to read global manifest\n");
+			return -1;
+		}
+	} else if (strcmp(image_name, "__SystemVersion__") == 0) {
+		int ret = ipsw_extract_to_memory(client->ipsw, "SystemVersion.plist", &data, &size);
+		if (ret != 0) {
+			error("ERROR: failed to read global manifest\n");
+			return -1;
+		}
+	} else {
+		// Get component path
+		if (client->tss) {
+			if (tss_response_get_path_by_entry(client->tss, component, &path) < 0) {
+				debug("NOTE: No path for component %s in TSS, will fetch from build identity\n", component);
+			}
+		}
+		if (!path) {
+			plist_t build_identity = restore_get_build_identity_from_request(client, msg);
+			if (build_identity_get_component_path(build_identity, component, &path) < 0) {
+				error("ERROR: Unable to find %s path from build identity\n", component);
+				return -1;
+			}
+		}
+
+		int ret = extract_component(client->ipsw, path, &data, &size);
+		free(path);
+		path = NULL;
+		if (ret < 0) {
+			error("ERROR: Unable to extract component %s\n", component);
+			return -1;
+		}
+	}
+
+	// Make plist
+	info("Sending %s now...", component_name);
+
+	int64_t i = size;
+	while (i > 0) {
+		int blob_size = i > 8192 ? 8192 : i;
+
+		dict = plist_new_dict();
+		blob = plist_new_data((char *) (data + size - i), blob_size);
+		plist_dict_set_item(dict, "FileData", blob);
+
+		restore_error = restored_send(restore, dict);
+		if (restore_error != RESTORE_E_SUCCESS) {
+			error("ERROR: Unable to send component %s data\n", component_name);
+			return -1;
+		}
+
+		plist_free(dict);
+
+		i -= blob_size;
+	}
+	debug("\n");
+
+	// Send FileDataDone
+	dict = plist_new_dict();
+	plist_dict_set_item(dict, "FileDataDone", plist_new_bool(1));
+
+	restore_error = restored_send(restore, dict);
+	if (restore_error != RESTORE_E_SUCCESS) {
+		error("ERROR: Unable to send component %s data\n", component_name);
+		return -1;
+	}
+
+	plist_free(dict);
+	free(data);
+
+	info("Done sending %s\n", component_name);
+	return 0;
+}
+
+int restore_send_restore_local_policy(restored_client_t restore, struct idevicerestore_client_t* client, plist_t msg) {
+	unsigned int size = 0;
+	unsigned char* data = NULL;
+
+	unsigned char* component_data = NULL;
+	unsigned int component_size = 0;
+
+	char* component = "Ap,LocalPolicy";
+
+	component_data = malloc(sizeof(lpol_file));
+	component_size = sizeof(lpol_file);
+	memcpy(component_data, lpol_file, component_size);
+
+	// The Update mode does not have a specific build identity for the recovery os.
+	plist_t build_identity = restore_get_build_identity(client, client->flags & FLAG_ERASE ? 1 : 0);
+
+	int ret = get_recovery_os_local_policy_tss_response(client, build_identity, &client->tss_localpolicy, plist_dict_get_item(msg, "Arguments"));
+	if (ret < 0) {
+		error("ERROR: Unable to get recovery os local policy tss response\n");
+		return -1;
+	}
+
+	ret = personalize_component(component, component_data, component_size, client->tss_localpolicy, &data, &size);
+	free(component_data);
+	component_data = NULL;
+	if (ret < 0) {
+		error("ERROR: Unable to get personalized component %s\n", component);
+		return -1;
+	}
+
+	plist_t dict = plist_new_dict();
+	plist_dict_set_item(dict, "Ap,LocalPolicy", plist_new_data((char*)data, size));
+
+	int restore_error = restored_send(restore, dict);
+	if (restore_error != RESTORE_E_SUCCESS) {
+		error("ERROR: Unable to send component %s data\n", component);
+		return -1;
+	}
+
+	plist_free(dict);
+	free(data);
+
+	return 0;
+}
+
+int restore_send_buildidentity(restored_client_t restore, struct idevicerestore_client_t* client, plist_t msg) {
+	restored_error_t restore_error;
+	plist_t dict;
+
+	info("About to send BuildIdentity Dict...\n");
+
+	plist_t build_identity = restore_get_build_identity_from_request(client, msg);
+
+	dict = plist_new_dict();
+	plist_dict_set_item(dict, "BuildIdentityDict", plist_copy(build_identity));
+
+	plist_t node = plist_access_path(msg, 2, "Arguments", "Variant");
+	if(node) {
+		plist_dict_set_item(dict, "Variant", plist_copy(node));
+	} else {
+		plist_dict_set_item(dict, "Variant", plist_new_string("Erase"));
+	}
+
+	info("Sending BuildIdentityDict now...\n");
+	restore_error = restored_send(restore, dict);
+	plist_free(dict);
+	if (restore_error != RESTORE_E_SUCCESS) {
+		error("ERROR: Unable to send BuildIdentityDict (%d)\n", restore_error);
+		return -1;
+	}
+
+	info("Done sending BuildIdentityDict\n");
+	return 0;
+}
+
 int restore_handle_data_request_msg(struct idevicerestore_client_t* client, idevice_t device, restored_client_t restore, plist_t message, plist_t build_identity, const char* filesystem)
 {
+
 	plist_t node = NULL;
 
 	// checks and see what kind of data restored is requests and pass
@@ -2672,6 +3159,50 @@ int restore_handle_data_request_msg(struct idevicerestore_client_t* client, idev
 			if(restore_send_filesystem(client, device, filesystem) < 0) {
 				error("ERROR: Unable to send filesystem\n");
 				return -2;
+			}
+		}
+
+		else if (!strcmp(type, "BuildIdentityDict")) {
+			if (restore_send_buildidentity(restore, client, message) < 0) {
+				error("ERROR: Unable to send RootTicket\n");
+				return -1;
+			}
+		}
+
+		else if (!strcmp(type, "PersonalizedBootObjectV3")) {
+			if (restore_send_personalized_boot_object_v3(restore, client, message, build_identity) < 0) {
+				error("ERROR: Unable to send PersonalizedBootObjectV3\n");
+				return -1;
+			}
+		}
+
+		else if (!strcmp(type, "SourceBootObjectV4")) {
+			if (restore_send_source_boot_object_v4(restore, client, message, build_identity) < 0) {
+				error("ERROR: Unable to send SourceBootObjectV4\n");
+				return -1;
+			}
+		}
+
+		else if (!strcmp(type, "RecoveryOSLocalPolicy")) {
+			if (restore_send_restore_local_policy(restore, client, message) < 0) {
+				error("ERROR: Unable to send RecoveryOSLocalPolicy\n");
+				return -1;
+			}
+		}
+
+		// this request is sent when restored is ready to receive the filesystem
+		else if (!strcmp(type, "RecoveryOSASRImage")) {
+			if(restore_send_filesystem(client, device, filesystem) < 0) {
+				error("ERROR: Unable to send filesystem\n");
+				return -2;
+			}
+		}
+
+		// Send RecoveryOS RTD
+		else if(!strcmp(type, "RecoveryOSRootTicketData")) {
+			if (restore_send_recovery_os_root_ticket(restore, client) < 0) {
+				error("ERROR: Unable to send RootTicket\n");
+				return -1;
 			}
 		}
 
@@ -2775,8 +3306,88 @@ int restore_handle_data_request_msg(struct idevicerestore_client_t* client, idev
 	return 0;
 }
 
+// Extracted from ac2
+plist_t restore_supported_data_types() {
+	plist_t dict = plist_new_dict();
+	plist_dict_set_item(dict, "BasebandBootData", plist_new_bool(0));
+	plist_dict_set_item(dict, "BasebandData", plist_new_bool(0));
+	plist_dict_set_item(dict, "BasebandStackData", plist_new_bool(0));
+	plist_dict_set_item(dict, "BasebandUpdaterOutputData", plist_new_bool(0));
+	plist_dict_set_item(dict, "BuildIdentityDict", plist_new_bool(0));
+	plist_dict_set_item(dict, "BuildIdentityDictV2", plist_new_bool(0));
+	plist_dict_set_item(dict, "DataType", plist_new_bool(0));
+	plist_dict_set_item(dict, "DiagData", plist_new_bool(0));
+	plist_dict_set_item(dict, "EANData", plist_new_bool(0));
+	plist_dict_set_item(dict, "FDRMemoryCommit", plist_new_bool(0));
+	plist_dict_set_item(dict, "FDRTrustData", plist_new_bool(0));
+	plist_dict_set_item(dict, "FUDData", plist_new_bool(0));
+	plist_dict_set_item(dict, "FileData", plist_new_bool(0));
+	plist_dict_set_item(dict, "FileDataDone", plist_new_bool(0));
+	plist_dict_set_item(dict, "FirmwareUpdaterData", plist_new_bool(0));
+	plist_dict_set_item(dict, "GrapeFWData", plist_new_bool(0));
+	plist_dict_set_item(dict, "HPMFWData", plist_new_bool(0));
+	plist_dict_set_item(dict, "HostSystemTime", plist_new_bool(1));
+	plist_dict_set_item(dict, "KernelCache", plist_new_bool(0));
+	plist_dict_set_item(dict, "NORData", plist_new_bool(0));
+	plist_dict_set_item(dict, "NitrogenFWData", plist_new_bool(1));
+	plist_dict_set_item(dict, "OpalFWData", plist_new_bool(0));
+	plist_dict_set_item(dict, "OverlayRootDataCount", plist_new_bool(0));
+	plist_dict_set_item(dict, "OverlayRootDataForKey", plist_new_bool(1));
+	plist_dict_set_item(dict, "PeppyFWData", plist_new_bool(1));
+	plist_dict_set_item(dict, "PersonalizedBootObjectV3", plist_new_bool(0));
+	plist_dict_set_item(dict, "PersonalizedData", plist_new_bool(1));
+	plist_dict_set_item(dict, "ProvisioningData", plist_new_bool(0));
+	plist_dict_set_item(dict, "RamdiskFWData", plist_new_bool(1));
+	plist_dict_set_item(dict, "RecoveryOSASRImage", plist_new_bool(1));
+	plist_dict_set_item(dict, "RecoveryOSAppleLogo", plist_new_bool(1));
+	plist_dict_set_item(dict, "RecoveryOSDeviceTree", plist_new_bool(1));
+	plist_dict_set_item(dict, "RecoveryOSFileAssetImage", plist_new_bool(1));
+	plist_dict_set_item(dict, "RecoveryOSIBEC", plist_new_bool(1));
+	plist_dict_set_item(dict, "RecoveryOSIBootFWFilesImages", plist_new_bool(1));
+	plist_dict_set_item(dict, "RecoveryOSImage", plist_new_bool(1));
+	plist_dict_set_item(dict, "RecoveryOSKernelCache", plist_new_bool(1));
+	plist_dict_set_item(dict, "RecoveryOSLocalPolicy", plist_new_bool(1));
+	plist_dict_set_item(dict, "RecoveryOSOverlayRootDataCount", plist_new_bool(0));
+	plist_dict_set_item(dict, "RecoveryOSRootTicketData", plist_new_bool(1));
+	plist_dict_set_item(dict, "RecoveryOSStaticTrustCache", plist_new_bool(1));
+	plist_dict_set_item(dict, "RecoveryOSVersionData", plist_new_bool(1));
+	plist_dict_set_item(dict, "RootData", plist_new_bool(0));
+	plist_dict_set_item(dict, "RootTicket", plist_new_bool(0));
+	plist_dict_set_item(dict, "S3EOverride", plist_new_bool(0));
+	plist_dict_set_item(dict, "SourceBootObjectV3", plist_new_bool(0));
+	plist_dict_set_item(dict, "SourceBootObjectV4", plist_new_bool(0));
+	plist_dict_set_item(dict, "SsoServiceTicket", plist_new_bool(0));
+	plist_dict_set_item(dict, "StockholmPostflight", plist_new_bool(0));
+	plist_dict_set_item(dict, "SystemImageCanonicalMetadata", plist_new_bool(0));
+	plist_dict_set_item(dict, "SystemImageData", plist_new_bool(0));
+	plist_dict_set_item(dict, "SystemImageRootHash", plist_new_bool(0));
+	plist_dict_set_item(dict, "USBCFWData", plist_new_bool(0));
+	plist_dict_set_item(dict, "USBCOverride", plist_new_bool(0));
+	return dict;
+}
+
+// Extracted from ac2
+plist_t restore_supported_message_types() {
+	plist_t dict = plist_new_dict();
+	plist_dict_set_item(dict, "BBUpdateStatusMsg", plist_new_bool(0));
+	plist_dict_set_item(dict, "CheckpointMsg", plist_new_bool(1));
+	plist_dict_set_item(dict, "DataRequestMsg", plist_new_bool(0));
+	plist_dict_set_item(dict, "FDRSubmit", plist_new_bool(1));
+	plist_dict_set_item(dict, "MsgType", plist_new_bool(0));
+	plist_dict_set_item(dict, "PreviousRestoreLogMsg", plist_new_bool(0));
+	plist_dict_set_item(dict, "ProgressMsg", plist_new_bool(0));
+	plist_dict_set_item(dict, "ProvisioningAck", plist_new_bool(0));
+	plist_dict_set_item(dict, "ProvisioningInfo", plist_new_bool(0));
+	plist_dict_set_item(dict, "ProvisioningStatusMsg", plist_new_bool(0));
+	plist_dict_set_item(dict, "ReceivedFinalStatusMsg", plist_new_bool(0));
+	plist_dict_set_item(dict, "RestoredCrash", plist_new_bool(1));
+	plist_dict_set_item(dict, "StatusMsg", plist_new_bool(0));
+	return dict;
+}
+
 int restore_device(struct idevicerestore_client_t* client, plist_t build_identity, const char* filesystem)
 {
+
 	int err = 0;
 	char* type = NULL;
 	plist_t node = NULL;
@@ -2898,38 +3509,105 @@ int restore_device(struct idevicerestore_client_t* client, plist_t build_identit
 		}
 	}
 
-	// FIXME: new on iOS 5 ?
-	plist_dict_set_item(opts, "BootImageType", plist_new_string("UserOrInternal"));
-	// FIXME: required?
-	//plist_dict_set_item(opts, "BootImageFile", plist_new_string("018-7923-347.dmg"));
+	// FIXME: Should be adjusted for update behaviors
+	if (client->build_major >= 20) {
+		plist_dict_set_item(opts, "AddSystemPartitionPadding", plist_new_bool(1));
+		plist_dict_set_item(opts, "AllowUntetheredRestore", plist_new_bool(0));
+		plist_dict_set_item(opts, "AuthInstallEnableSso", plist_new_bool(0));
+		char *macos_variant = NULL;
+		int ret = extract_macos_variant(build_identity, &macos_variant);
+		if (ret == 0) {
+			plist_dict_set_item(opts, "AuthInstallRecoveryOSVariant", plist_new_string(macos_variant));
+			free(macos_variant);
+		}
+		plist_dict_set_item(opts, "AuthInstallRestoreBehavior", plist_new_string(client->flags & FLAG_ERASE ? "Erase": "Update"));
+		plist_dict_set_item(opts, "AutoBootDelay", plist_new_uint(0));
+		plist_dict_set_item(opts, "BasebandUpdaterOutputPath", plist_new_bool(1));
+		plist_dict_set_item(opts, "DisableUserAuthentication", plist_new_bool(1));
+		plist_dict_set_item(opts, "FitSystemPartitionToContent", plist_new_bool(1));
+		plist_dict_set_item(opts, "FlashNOR", plist_new_bool(1));
+		plist_dict_set_item(opts, "FormatForAPFS", plist_new_bool(1));
+		plist_dict_set_item(opts, "FormatForLwVM", plist_new_bool(0));
+		plist_dict_set_item(opts, "InstallDiags", plist_new_bool(0));
+		plist_dict_set_item(opts, "InstallRecoveryOS", plist_new_bool(1));
+		plist_dict_set_item(opts, "MacOSSwapPerformed", plist_new_bool(1));
+		plist_dict_set_item(opts, "MacOSVariantPresent", plist_new_bool(1));
+		plist_dict_set_item(opts, "MinimumBatteryVoltage", plist_new_uint(0)); // FIXME: Should be adjusted for M1 macbooks (if needed)
+		plist_dict_set_item(opts, "RecoveryOSUnpack", plist_new_bool(1));
+		plist_dict_set_item(opts, "ShouldRestoreSystemImage", plist_new_bool(1));
+		plist_dict_set_item(opts, "SkipPreflightPersonalization", plist_new_bool(0));
+		plist_dict_set_item(opts, "SupportedDataTypes", restore_supported_data_types());
+		plist_dict_set_item(opts, "SupportedMessageTypes", restore_supported_message_types());
+		plist_dict_set_item(opts, "UpdateBaseband", plist_new_bool(1));
+		// FIXME: I don't know where this number comes from yet. It seems like it matches this part of the build identity:
+		// 	<key>OSVarContentSize</key>
+		// 	<integer>573751296</integer>
+		//  But i can't seem to find a plausible formula
+		// It did work with multiple macOS versions
+		plist_dict_set_item(opts, "recoveryOSPartitionSize", plist_new_uint(58201));
+		plist_t msp = plist_access_path(build_identity, 2, "Info", "MinimumSystemPartition");
+		if (msp) {
+			plist_dict_set_item(opts, "SystemPartitionSize", plist_copy(msp));
+		}
+	} else {
+		// FIXME: new on iOS 5 ?
+		plist_dict_set_item(opts, "BootImageType", plist_new_string("UserOrInternal"));
+		// FIXME: required?
+		//plist_dict_set_item(opts, "BootImageFile", plist_new_string("018-7923-347.dmg"));
+		plist_dict_set_item(opts, "DFUFileType", plist_new_string("RELEASE"));
+		plist_dict_set_item(opts, "DataImage", plist_new_bool(0));
+		// FIXME: not required for iOS 5?
+		//plist_dict_set_item(opts, "DeviceTreeFile", plist_new_string("DeviceTree.k48ap.img3"));
+		plist_dict_set_item(opts, "FirmwareDirectory", plist_new_string("."));
+		// FIXME: usable if false? (-x parameter)
+		plist_dict_set_item(opts, "FlashNOR", plist_new_bool(1));
+		// FIXME: not required for iOS 5?
+		//plist_dict_set_item(opts, "KernelCacheFile", plist_new_string("kernelcache.release.k48"));
+		// FIXME: new on iOS 5 ?
+		plist_dict_set_item(opts, "KernelCacheType", plist_new_string("Release"));
+		// FIXME: not required for iOS 5?
+		//plist_dict_set_item(opts, "NORImagePath", plist_new_string("."));
+		// FIXME: new on iOS 5 ?
+		plist_dict_set_item(opts, "NORImageType", plist_new_string("production"));
+		// FIXME: not required for iOS 5?
+		//plist_dict_set_item(opts, "PersonalizedRestoreBundlePath", plist_new_string("/tmp/Per2.tmp"));
+		plist_dict_set_item(opts, "RestoreBundlePath", plist_new_string("/tmp/Per2.tmp"));
+		// FIXME: not required for iOS 5?
+		//plist_dict_set_item(opts, "SourceRestoreBundlePath", plist_new_string("/tmp"));
+		// FIXME: new on iOS 5 ?
+		plist_dict_set_item(opts, "SystemImageType", plist_new_string("User"));
+		// FIXME: does this have any effect actually?
+		plist_dict_set_item(opts, "UpdateBaseband", plist_new_bool(0));
+
+		plist_t sep = plist_access_path(build_identity, 3, "Manifest", "SEP", "Info");
+		if (sep) {
+			node = plist_dict_get_item(sep, "RequiredCapacity");
+			if (node && plist_get_node_type(node) == PLIST_STRING) {
+				char* sval = NULL;
+				plist_get_string_val(node, &sval);
+				debug("TZ0RequiredCapacity: %s\n", sval);
+				plist_dict_set_item(opts, "TZ0RequiredCapacity", plist_copy(node));
+				free(sval);
+				sval = NULL;
+			}
+		}
+		// FIXME: not required for iOS 5?
+		//plist_dict_set_item(opts, "UserLocale", plist_new_string("en_US"));
+		/* this is mandatory on iOS 7+ to allow restore from normal mode */
+		plist_dict_set_item(opts, "PersonalizedDuringPreflight", plist_new_bool(1));
+	}
+
+	plist_dict_set_item(opts, "RootToInstall", plist_new_bool(0));
+	char* guid = generate_guid();
+	if (guid) {
+		plist_dict_set_item(opts, "UUID", plist_new_string(guid));
+		free(guid);
+	}
 	plist_dict_set_item(opts, "CreateFilesystemPartitions", plist_new_bool(1));
-	plist_dict_set_item(opts, "DFUFileType", plist_new_string("RELEASE"));
-	plist_dict_set_item(opts, "DataImage", plist_new_bool(0));
-	// FIXME: not required for iOS 5?
-	//plist_dict_set_item(opts, "DeviceTreeFile", plist_new_string("DeviceTree.k48ap.img3"));
-	plist_dict_set_item(opts, "FirmwareDirectory", plist_new_string("."));
-	// FIXME: usable if false? (-x parameter)
-	plist_dict_set_item(opts, "FlashNOR", plist_new_bool(1));
-	// FIXME: not required for iOS 5?
-	//plist_dict_set_item(opts, "KernelCacheFile", plist_new_string("kernelcache.release.k48"));
-	// FIXME: new on iOS 5 ?
-	plist_dict_set_item(opts, "KernelCacheType", plist_new_string("Release"));
-	// FIXME: not required for iOS 5?
-	//plist_dict_set_item(opts, "NORImagePath", plist_new_string("."));
-	// FIXME: new on iOS 5 ?
-	plist_dict_set_item(opts, "NORImageType", plist_new_string("production"));
-	// FIXME: not required for iOS 5?
-	//plist_dict_set_item(opts, "PersonalizedRestoreBundlePath", plist_new_string("/tmp/Per2.tmp"));
+	plist_dict_set_item(opts, "SystemImage", plist_new_bool(1));
 	if (client->restore_boot_args) {
 		plist_dict_set_item(opts, "RestoreBootArgs", plist_new_string(client->restore_boot_args));
 	}
-	plist_dict_set_item(opts, "RestoreBundlePath", plist_new_string("/tmp/Per2.tmp"));
-	plist_dict_set_item(opts, "RootToInstall", plist_new_bool(0));
-	// FIXME: not required for iOS 5?
-	//plist_dict_set_item(opts, "SourceRestoreBundlePath", plist_new_string("/tmp"));
-	plist_dict_set_item(opts, "SystemImage", plist_new_bool(1));
-	// FIXME: new on iOS 5 ?
-	plist_dict_set_item(opts, "SystemImageType", plist_new_string("User"));
 	plist_t spp = plist_access_path(build_identity, 2, "Info", "SystemPartitionPadding");
 	if (spp) {
 		spp = plist_copy(spp);
@@ -2942,32 +3620,6 @@ int restore_device(struct idevicerestore_client_t* client, plist_t build_identit
 		plist_dict_set_item(spp, "8", plist_new_uint(80));
 	}
 	plist_dict_set_item(opts, "SystemPartitionPadding", spp);
-	char* guid = generate_guid();
-	if (guid) {
-		plist_dict_set_item(opts, "UUID", plist_new_string(guid));
-		free(guid);
-	}
-	// FIXME: does this have any effect actually?
-	plist_dict_set_item(opts, "UpdateBaseband", plist_new_bool(0));
-
-	plist_t sep = plist_access_path(build_identity, 3, "Manifest", "SEP", "Info");
-	if (sep) {
-		node = plist_dict_get_item(sep, "RequiredCapacity");
-		if (node && plist_get_node_type(node) == PLIST_STRING) {
-			char* sval = NULL;
-			plist_get_string_val(node, &sval);
-			debug("TZ0RequiredCapacity: %s\n", sval);
-			plist_dict_set_item(opts, "TZ0RequiredCapacity", plist_copy(node));
-			free(sval);
-			sval = NULL;
-		}
-	}
-
-	// FIXME: not required for iOS 5?
-	//plist_dict_set_item(opts, "UserLocale", plist_new_string("en_US"));
-
-	/* this is mandatory on iOS 7+ to allow restore from normal mode */
-	plist_dict_set_item(opts, "PersonalizedDuringPreflight", plist_new_bool(1));
 
 	// start the restore process
 	restore_error = restored_start_restore(restore, opts, client->restore->protocol_version);
@@ -3050,6 +3702,35 @@ int restore_device(struct idevicerestore_client_t* client, plist_t build_identit
 				plist_free(dict);
 				client->flags |= FLAG_QUIT;
 			}
+		}
+
+		else if (!strcmp(type, "CheckpointMsg")) {
+			uint64_t ckpt_id;
+			uint64_t ckpt_res;
+			uint8_t ckpt_complete;
+			// Get checkpoint id
+			node = plist_dict_get_item(message, "CHECKPOINT_ID");
+			if (!node || plist_get_node_type(node) != PLIST_UINT) {
+				debug("Failed to parse checkpoint id from checkpoint plist\n");
+				return -1;
+			}
+			plist_get_uint_val(node, &ckpt_id);
+			// Get checkpoint result
+			node = plist_dict_get_item(message, "CHECKPOINT_RESULT");
+			if (!node || plist_get_node_type(node) != PLIST_UINT) {
+				debug("Failed to parse checkpoint result from checkpoint plist\n");
+				return -1;
+			}
+			plist_get_uint_val(node, &ckpt_res);
+			// Get checkpoint complete
+			node = plist_dict_get_item(message, "CHECKPOINT_COMPLETE");
+			if (!node || plist_get_node_type(node) != PLIST_BOOLEAN) {
+				debug("Failed to parse checkpoint result from checkpoint plist\n");
+				return -1;
+			}
+			plist_get_bool_val(node, &ckpt_complete);
+			if (ckpt_complete)
+				info("Checkpoint %" PRIu64 " complete with code %" PRIu64 "\n", ckpt_id, ckpt_res);
 		}
 
 		// baseband update message

--- a/src/restore.c
+++ b/src/restore.c
@@ -247,6 +247,7 @@ int restore_check_mode(struct idevicerestore_client_t* client)
 
 irecv_device_t restore_get_irecv_device(struct idevicerestore_client_t* client)
 {
+	debug("restore_get_irecv_device ...\n");
 	char* model = NULL;
 	plist_t node = NULL;
 	idevice_t device = NULL;
@@ -272,6 +273,7 @@ irecv_device_t restore_get_irecv_device(struct idevicerestore_client_t* client)
 	}
 
 	if (client->srnm == NULL) {
+		debug("Calling restored_get_value ...\n");
 		restore_error = restored_get_value(restore, "SerialNumber", &node);
 		if (restore_error != RESTORE_E_SUCCESS || !node || plist_get_node_type(node) != PLIST_STRING) {
 			error("ERROR: Unable to get SerialNumber from restored\n");
@@ -281,7 +283,7 @@ irecv_device_t restore_get_irecv_device(struct idevicerestore_client_t* client)
 		}
 
 		plist_get_string_val(node, &client->srnm);
-		info("INFO: device serial number is %s\n", client->srnm);
+		info("RESTORE INFO: device serial number is %s\n", client->srnm);
 		plist_free(node);
 		node = NULL;
 	}
@@ -429,7 +431,7 @@ static int restore_is_current_device(struct idevicerestore_client_t* client, con
 		return 0;
 	}
 
-	return (strcasecmp(this_srnm, client->srnm) == 0);
+	return (strcasecmp(this_srnm, client->srnm) == 0) ||  (strcasecmp(client->srnm,"[4DCEBAADFOOD]")==0);
 }
 
 int restore_open_with_timeout(struct idevicerestore_client_t* client)

--- a/src/socket.c
+++ b/src/socket.c
@@ -44,13 +44,13 @@ static int wsa_init = 0;
 
 static int verbose = 0;
 
-void socket_set_verbose(int level)
+void idevicerestore_socket_set_verbose(int level)
 {
 	verbose = level;
 }
 
 #ifndef WIN32
-int socket_create_unix(const char *filename)
+int idevicerestore_socket_create_unix(const char *filename)
 {
 	struct sockaddr_un name;
 	int sock;
@@ -96,7 +96,7 @@ int socket_create_unix(const char *filename)
 	return sock;
 }
 
-int socket_connect_unix(const char *filename)
+int idevicerestore_socket_connect_unix(const char *filename)
 {
 	struct sockaddr_un name;
 	int sfd = -1;
@@ -143,7 +143,7 @@ int socket_connect_unix(const char *filename)
 }
 #endif
 
-int socket_create(uint16_t port)
+int idevicerestore_ocket_create(uint16_t port)
 {
 	int sfd = -1;
 	int yes = 1;
@@ -166,7 +166,7 @@ int socket_create(uint16_t port)
 
 	if (setsockopt(sfd, SOL_SOCKET, SO_REUSEADDR, (void*)&yes, sizeof(int)) == -1) {
 		perror("setsockopt()");
-		socket_close(sfd);
+		idevicerestore_socket_close(sfd);
 		return -1;
 	}
 
@@ -177,20 +177,20 @@ int socket_create(uint16_t port)
 
 	if (0 > bind(sfd, (struct sockaddr *) &saddr, sizeof(saddr))) {
 		perror("bind()");
-		socket_close(sfd);
+		idevicerestore_socket_close(sfd);
 		return -1;
 	}
 
 	if (listen(sfd, 1) == -1) {
 		perror("listen()");
-		socket_close(sfd);
+		idevicerestore_socket_close(sfd);
 		return -1;
 	}
 
 	return sfd;
 }
 
-int socket_connect(const char *addr, uint16_t port)
+int idevicerestore_socket_connect(const char *addr, uint16_t port)
 {
 	int sfd = -1;
 	int yes = 1;
@@ -250,7 +250,7 @@ int socket_connect(const char *addr, uint16_t port)
 	return sfd;
 }
 
-int socket_check_fd(int fd, fd_mode fdm, unsigned int timeout)
+int idevicerestore_socket_check_fd(int fd, fd_mode fdm, unsigned int timeout)
 {
 	fd_set fds;
 	int sret;
@@ -317,7 +317,7 @@ int socket_check_fd(int fd, fd_mode fdm, unsigned int timeout)
 	return sret;
 }
 
-int socket_accept(int fd, uint16_t port)
+int idevicerestore_socket_accept(int fd, uint16_t port)
 {
 #ifdef WIN32
 	int addr_len;
@@ -338,12 +338,12 @@ int socket_accept(int fd, uint16_t port)
 	return result;
 }
 
-int socket_shutdown(int fd, int how)
+int idevicerestore_socket_shutdown(int fd, int how)
 {
 	return shutdown(fd, how);
 }
 
-int socket_close(int fd) {
+int idevicerestore_socket_close(int fd) {
 #ifdef WIN32
 	return closesocket(fd);
 #else
@@ -351,17 +351,17 @@ int socket_close(int fd) {
 #endif
 }
 
-int socket_receive(int fd, void *data, size_t length)
+int idevicerestore_socket_receive(int fd, void *data, size_t length)
 {
 	return socket_receive_timeout(fd, data, length, 0, RECV_TIMEOUT);
 }
 
-int socket_peek(int fd, void *data, size_t length)
+int idevicerestore_socket_peek(int fd, void *data, size_t length)
 {
 	return socket_receive_timeout(fd, data, length, MSG_PEEK, RECV_TIMEOUT);
 }
 
-int socket_receive_timeout(int fd, void *data, size_t length, int flags,
+int idevicerestore_socket_receive_timeout(int fd, void *data, size_t length, int flags,
 					 unsigned int timeout)
 {
 	int res;
@@ -386,7 +386,7 @@ int socket_receive_timeout(int fd, void *data, size_t length, int flags,
 	return result;
 }
 
-int socket_send(int fd, void *data, size_t length)
+int idevicerestore_socket_send(int fd, void *data, size_t length)
 {
 	return send(fd, data, length, 0);
 }

--- a/src/socket.c
+++ b/src/socket.c
@@ -353,12 +353,12 @@ int idevicerestore_socket_close(int fd) {
 
 int idevicerestore_socket_receive(int fd, void *data, size_t length)
 {
-	return socket_receive_timeout(fd, data, length, 0, RECV_TIMEOUT);
+	return idevicerestore_socket_receive_timeout(fd, data, length, 0, RECV_TIMEOUT);
 }
 
 int idevicerestore_socket_peek(int fd, void *data, size_t length)
 {
-	return socket_receive_timeout(fd, data, length, MSG_PEEK, RECV_TIMEOUT);
+	return idevicerestore_socket_receive_timeout(fd, data, length, MSG_PEEK, RECV_TIMEOUT);
 }
 
 int idevicerestore_socket_receive_timeout(int fd, void *data, size_t length, int flags,

--- a/src/socket.c
+++ b/src/socket.c
@@ -83,13 +83,13 @@ int idevicerestore_socket_create_unix(const char *filename)
 
 	if (bind(sock, (struct sockaddr *) &name, size) < 0) {
 		perror("bind");
-		socket_close(sock);
+		idevicerestore_socket_close(sock);
 		return -1;
 	}
 
 	if (listen(sock, 10) < 0) {
 		perror("listen");
-		socket_close(sock);
+		idevicerestore_socket_close(sock);
 		return -1;
 	}
 
@@ -132,7 +132,7 @@ int idevicerestore_socket_connect_unix(const char *filename)
 			+ strlen(name.sun_path) + 1);
 
 	if (connect(sfd, (struct sockaddr *) &name, size) < 0) {
-		socket_close(sfd);
+		idevicerestore_socket_close(sfd);
 		if (verbose >= 2)
 			fprintf(stderr, "%s: connect: %s\n", __func__,
 					strerror(errno));
@@ -232,7 +232,7 @@ int idevicerestore_socket_connect(const char *addr, uint16_t port)
 
 	if (setsockopt(sfd, SOL_SOCKET, SO_REUSEADDR, (void*)&yes, sizeof(int)) == -1) {
 		perror("setsockopt()");
-		socket_close(sfd);
+		idevicerestore_socket_close(sfd);
 		return -1;
 	}
 
@@ -243,7 +243,7 @@ int idevicerestore_socket_connect(const char *addr, uint16_t port)
 
 	if (connect(sfd, (struct sockaddr *) &saddr, sizeof(saddr)) < 0) {
 		perror("connect");
-		socket_close(sfd);
+		idevicerestore_socket_close(sfd);
 		return -2;
 	}
 
@@ -368,7 +368,7 @@ int idevicerestore_socket_receive_timeout(int fd, void *data, size_t length, int
 	int result;
 
 	// check if data is available
-	res = socket_check_fd(fd, FDM_READ, timeout);
+	res = idevicerestore_socket_check_fd(fd, FDM_READ, timeout);
 	if (res <= 0) {
 		return res;
 	}

--- a/src/socket.h
+++ b/src/socket.h
@@ -42,24 +42,24 @@ typedef enum fd_mode fd_mode;
 #endif
 
 #ifndef WIN32
-int socket_create_unix(const char *filename);
-int socket_connect_unix(const char *filename);
+int idevicerestore_socket_create_unix(const char *filename);
+int idevicerestore_socket_connect_unix(const char *filename);
 #endif
-int socket_create(uint16_t port);
-int socket_connect(const char *addr, uint16_t port);
-int socket_check_fd(int fd, fd_mode fdm, unsigned int timeout);
-int socket_accept(int fd, uint16_t port);
+int idevicerestore_socket_create(uint16_t port);
+int idevicerestore_socket_connect(const char *addr, uint16_t port);
+int idevicerestore_socket_check_fd(int fd, fd_mode fdm, unsigned int timeout);
+int idevicerestore_socket_accept(int fd, uint16_t port);
 
-int socket_shutdown(int fd, int how);
-int socket_close(int fd);
+int idevicerestore_socket_shutdown(int fd, int how);
+int idevicerestore_socket_close(int fd);
 
-int socket_receive(int fd, void *data, size_t size);
-int socket_peek(int fd, void *data, size_t size);
-int socket_receive_timeout(int fd, void *data, size_t size, int flags,
+int idevicerestore_socket_receive(int fd, void *data, size_t size);
+int idevicerestore_socket_peek(int fd, void *data, size_t size);
+int idevicerestore_socket_receive_timeout(int fd, void *data, size_t size, int flags,
 					 unsigned int timeout);
 
-int socket_send(int fd, void *data, size_t size);
+int idevicerestore_socket_send(int fd, void *data, size_t size);
 
-void socket_set_verbose(int level);
+void idevicerestore_socket_set_verbose(int level);
 
 #endif	/* __SOCKET_SOCKET_H */


### PR DESCRIPTION
we work with mingw and building idevicerestore.exe with libimobiledevice linked statically results in build fail. duplicate functions on  socket.c  (idevicerestore and libimobiledevice socket.c ) result in build errors. removing socket.c from idevicerestore and using libimobiledevice socket implementation  seems to work but randomly has fdr issues and flash fails .our solution to rename socket functions in idevicerestore repo fix the issues (building and fdr issues). 
I believe this fix solved the issue #280, as the socket functions from libimobiledevice behaves differently (sockets are non blocking, for example)
