### PR TITLE
Fixed return code in normal_enter_recovery method if lockdownd reques…

### DIFF
--- a/src/normal.c
+++ b/src/normal.c
@@ -241,7 +241,7 @@ int normal_enter_recovery(struct idevicerestore_client_t* client)
 		if (LOCKDOWN_E_SUCCESS != (lockdown_error = lockdownd_client_new_with_handshake(device, &lockdown, "idevicerestore"))) {
 			error("ERROR: Could not connect to lockdownd: %s (%d)\n", lockdownd_strerror(lockdown_error), lockdown_error);
 			idevice_free(device);
-			return 1;
+			return -1;
 		}
 		lockdown_error = lockdownd_enter_recovery(lockdown);
 	}


### PR DESCRIPTION
In "normal_enter_recovery(..)" method positive errorcode was returned, which is not threaded as error. Resulting process to continue execution even entering to recovery mode has failed.

Logs:
Entering recovery mode...
ERROR: Could not connect to lockdownd: Pairing dialog response pending (-19)
Waiting for device to enter restore mode...