### PR TITLE
Fix macOS Update behavior local policy TSS

### DIFF
--- a/src/restore.c
+++ b/src/restore.c
@@ -3045,7 +3045,8 @@ int restore_send_restore_local_policy(restored_client_t restore, struct idevicer
 	component_size = sizeof(lpol_file);
 	memcpy(component_data, lpol_file, component_size);
 
-	plist_t build_identity = restore_get_build_identity(client, 1);
+	// The Update mode does not have a specific build identity for the recovery os.
+	plist_t build_identity = restore_get_build_identity(client, client->flags & FLAG_ERASE ? 1 : 0);
 
 	int ret = get_recovery_os_local_policy_tss_response(client, build_identity, &client->tss_localpolicy, plist_dict_get_item(msg, "Arguments"));
 	if (ret < 0) {


### PR DESCRIPTION
This pull request fixes the local policy TSS error for macOS.

It happened because there's no special build identity when using the Update behavior to sign the recoveryOS local policy. Hence we switch back to the original build identity for this behavior.