### PR TITLE
Fix restore rules not being applied for recoveryos root ticket

### DIFF
--- a/src/idevicerestore.c
+++ b/src/idevicerestore.c
@@ -2392,6 +2392,9 @@ int get_recoveryos_root_ticket_tss_response(struct idevicerestore_client_t* clie
 	/* ApSecurityMode */
 	if (client->image4supported) {
 		plist_dict_set_item(parameters, "ApSecurityMode", plist_new_bool(1));
+		plist_dict_set_item(parameters, "ApSupportsImg4", plist_new_bool(1));
+	} else {
+		plist_dict_set_item(parameters, "ApSupportsImg4", plist_new_bool(0));
 	}
 
 	tss_parameters_add_from_manifest(parameters, build_identity);

--- a/src/tss.c
+++ b/src/tss.c
@@ -880,10 +880,6 @@ int tss_request_add_ap_recovery_tags(plist_t request, plist_t parameters, plist_
 		/* copy this entry */
 		plist_t tss_entry = plist_copy(manifest_entry);
 
-		// ac2 TSS recoveryOSRootTicket needs EPRO and ESEC to be true
-		plist_dict_set_item(tss_entry, "EPRO", plist_new_bool(1));
-		plist_dict_set_item(tss_entry, "ESEC", plist_new_bool(1));
-
 		/* remove obsolete Info node */
 		plist_dict_remove_item(tss_entry, "Info");
 


### PR DESCRIPTION
Hello, 

This PR should fix issue #411 

It basically applies correctly the request rules when getting the recovery os root ticket, instead of bruteforcing the values to 1.