### PR TITLE
Support macOS 12+ (Monterey)

### DIFF
--- a/src/idevicerestore.h
+++ b/src/idevicerestore.h
@@ -101,12 +101,7 @@ int build_manifest_get_identity_count(plist_t build_manifest);
 int build_manifest_check_compatibility(plist_t build_manifest, const char* product);
 void build_manifest_get_version_information(plist_t build_manifest, struct idevicerestore_client_t* client);
 plist_t build_manifest_get_build_identity_for_model(plist_t build_manifest, const char *hardware_model);
-plist_t build_manifest_get_build_identity_for_model_with_restore_behavior(plist_t build_manifest, const char *hardware_model, const char *behavior);
-plist_t build_manifest_get_build_identity_for_model_with_restore_behavior_and_global_signing(
-		plist_t build_manifest,
-		const char *hardware_model,
-		const char *behavior,
-		uint8_t global_signing);
+plist_t build_manifest_get_build_identity_for_model_with_variant(plist_t build_manifest, const char *hardware_model, const char *variant);
 int build_manifest_get_build_count(plist_t build_manifest);
 void build_identity_print_information(plist_t build_identity);
 int build_identity_check_components_in_ipsw(plist_t build_identity, const char* ipsw);

--- a/src/ipsw.h
+++ b/src/ipsw.h
@@ -30,8 +30,11 @@ extern "C" {
 
 #include <stdint.h>
 #include <plist/plist.h>
+#include <sys/stat.h>
 
 int ipsw_print_info(const char* ipsw);
+
+typedef int (*ipsw_list_cb)(void *ctx, const char* ipsw, const char *name, struct stat *stat);
 
 int ipsw_is_directory(const char* ipsw);
 int ipsw_file_exists(const char* ipsw, const char* infile);
@@ -41,6 +44,7 @@ int ipsw_extract_to_file_with_progress(const char* ipsw, const char* infile, con
 int ipsw_extract_to_memory(const char* ipsw, const char* infile, unsigned char** pbuffer, unsigned int* psize);
 int ipsw_extract_build_manifest(const char* ipsw, plist_t* buildmanifest, int *tss_enabled);
 int ipsw_extract_restore_plist(const char* ipsw, plist_t* restore_plist);
+int ipsw_list_contents(const char* ipsw, ipsw_list_cb cb, void *ctx);
 
 int ipsw_get_signed_firmwares(const char* product, plist_t* firmwares);
 int ipsw_download_fw(const char *fwurl, unsigned char* isha1, const char* todir, char** ipswfile);

--- a/src/restore.c
+++ b/src/restore.c
@@ -2802,16 +2802,23 @@ plist_t restore_get_build_identity(struct idevicerestore_client_t* client, uint8
 {
 	unsigned int size = 0;
 	unsigned char* data = NULL;
+	const char *variant;
 	plist_t buildmanifest = NULL;
 	ipsw_extract_to_memory(client->ipsw, "BuildManifest.plist", &data, &size);
 	plist_from_xml((char*)data, size, &buildmanifest);
 	free(data);
 
-	plist_t build_identity = build_manifest_get_build_identity_for_model_with_restore_behavior_and_global_signing(
+	if (is_recover_os)
+		variant = "macOS Customer";
+	else if (client->flags & FLAG_ERASE)
+		variant = "Customer Erase Install (IPSW)";
+	else
+		variant = "Customer Upgrade Install (IPSW)";
+
+	plist_t build_identity = build_manifest_get_build_identity_for_model_with_variant(
 			buildmanifest,
 			client->device->hardware_model,
-			client->flags & FLAG_ERASE ? "Erase": "Update",
-			is_recover_os);
+			variant);
 
 	plist_t unique_id_node = plist_dict_get_item(buildmanifest, "UniqueBuildID");
 	debug_plist(unique_id_node);

--- a/src/restore.c
+++ b/src/restore.c
@@ -3127,7 +3127,7 @@ int restore_send_personalized_boot_object_v3(restored_client_t restore, struct i
 	}
 
 	// Make plist
-	info("Sending %s now...", component_name);
+	info("Sending %s now...\n", component_name);
 
 	int64_t i = size;
 	while (i > 0) {
@@ -3237,7 +3237,7 @@ int restore_send_source_boot_object_v4(restored_client_t restore, struct idevice
 	}
 
 	// Make plist
-	info("Sending %s now...", component_name);
+	info("Sending %s now...\n", component_name);
 
 	int64_t i = size;
 	while (i > 0) {


### PR DESCRIPTION
This adds support for sending BootabilityBundle, a new component introduced in macOS 12+. This required some new scaffolding to enumerate files in the IPSW and send a subtree as a CPIO archive.

Tested by doing erase and non-erase restores on an M1 iMac.