### PR TITLE
Fix support for ios16 (#492)

### DIFF
--- a/src/idevicerestore.c
+++ b/src/idevicerestore.c
@@ -2042,7 +2042,7 @@ int get_preboard_manifest(struct idevicerestore_client_t* client, plist_t build_
 	plist_dict_set_item(parameters, "ApSecurityMode", plist_new_bool(0));
 	plist_dict_set_item(parameters, "ApSupportsImg4", plist_new_bool(1));
 
-	tss_parameters_add_from_manifest(parameters, build_identity);
+	tss_parameters_add_from_manifest(parameters, build_identity, true);
 
 	/* create basic request */
 	request = tss_request_new(NULL);
@@ -2173,7 +2173,7 @@ int get_tss_response(struct idevicerestore_client_t* client, plist_t build_ident
 		plist_dict_set_item(parameters, "ApSupportsImg4", plist_new_bool(0));
 	}
 
-	tss_parameters_add_from_manifest(parameters, build_identity);
+	tss_parameters_add_from_manifest(parameters, build_identity, true);
 
 	/* create basic request */
 	request = tss_request_new(NULL);
@@ -2301,7 +2301,7 @@ int get_recoveryos_root_ticket_tss_response(struct idevicerestore_client_t* clie
 		plist_dict_set_item(parameters, "ApSupportsImg4", plist_new_bool(0));
 	}
 
-	tss_parameters_add_from_manifest(parameters, build_identity);
+	tss_parameters_add_from_manifest(parameters, build_identity, true);
 
 	/* create basic request */
 	/* Adds @BBTicket, @HostPlatformInfo, @VersionInfo, @UUID */
@@ -2381,7 +2381,7 @@ int get_recovery_os_local_policy_tss_response(
 		plist_dict_set_item(parameters, "ApSupportsImg4", plist_new_bool(0));
 	}
 
-	tss_parameters_add_from_manifest(parameters, build_identity);
+	tss_parameters_add_from_manifest(parameters, build_identity, true);
 
 	// Add Ap,LocalPolicy
 	uint8_t digest[SHA384_DIGEST_LENGTH];
@@ -2476,7 +2476,7 @@ int get_local_policy_tss_response(struct idevicerestore_client_t* client, plist_
 		plist_dict_set_item(parameters, "ApSupportsImg4", plist_new_bool(0));
 	}
 
-	tss_parameters_add_from_manifest(parameters, build_identity);
+	tss_parameters_add_from_manifest(parameters, build_identity, true);
 
 	// Add Ap,LocalPolicy
 	uint8_t digest[SHA384_DIGEST_LENGTH];

--- a/src/restore.c
+++ b/src/restore.c
@@ -2757,7 +2757,7 @@ static plist_t restore_get_timer_firmware_data(restored_client_t restore, struct
 		plist_free(parameters);
 		return NULL;
 	} else {
-		plist_dict_merge(parameters, ap_info);
+		plist_dict_merge(&parameters, ap_info);
 	}
 
 	/* add required tags for Timer TSS request */

--- a/src/restore.c
+++ b/src/restore.c
@@ -1826,7 +1826,7 @@ static int restore_send_baseband_data(restored_client_t restore, struct idevicer
 		plist_dict_set_item(parameters, "BbGoldCertId", plist_new_uint(bb_cert_id));
 		plist_dict_set_item(parameters, "BbSNUM", plist_new_data((const char*)bb_snum, bb_snum_size));
 
-		tss_parameters_add_from_manifest(parameters, build_identity);
+		tss_parameters_add_from_manifest(parameters, build_identity, true);
 
 		/* create baseband request */
 		plist_t request = tss_request_new(NULL);
@@ -2167,7 +2167,7 @@ static plist_t restore_get_se_firmware_data(restored_client_t restore, struct id
 	parameters = plist_new_dict();
 
 	/* add manifest for current build_identity to parameters */
-	tss_parameters_add_from_manifest(parameters, build_identity);
+	tss_parameters_add_from_manifest(parameters, build_identity, true);
 
 	/* add SE,* tags from info dictionary to parameters */
 	plist_dict_merge(&parameters, p_info);
@@ -2222,7 +2222,7 @@ static plist_t restore_get_savage_firmware_data(restored_client_t restore, struc
 	parameters = plist_new_dict();
 
 	/* add manifest for current build_identity to parameters */
-	tss_parameters_add_from_manifest(parameters, build_identity);
+	tss_parameters_add_from_manifest(parameters, build_identity, true);
 
 	/* add Savage,* tags from info dictionary to parameters */
 	plist_dict_merge(&parameters, p_info);
@@ -2314,7 +2314,7 @@ static plist_t restore_get_yonkers_firmware_data(restored_client_t restore, stru
 	parameters = plist_new_dict();
 
 	/* add manifest for current build_identity to parameters */
-	tss_parameters_add_from_manifest(parameters, build_identity);
+	tss_parameters_add_from_manifest(parameters, build_identity, true);
 
 	/* add Yonkers,* tags from info dictionary to parameters */
 	plist_dict_merge(&parameters, p_info);
@@ -2400,7 +2400,7 @@ static plist_t restore_get_rose_firmware_data(restored_client_t restore, struct 
 	parameters = plist_new_dict();
 
 	/* add manifest for current build_identity to parameters */
-	tss_parameters_add_from_manifest(parameters, build_identity);
+	tss_parameters_add_from_manifest(parameters, build_identity, true);
 
 	plist_dict_set_item(parameters, "ApProductionMode", plist_new_bool(1));
 	if (client->image4supported) {
@@ -2532,7 +2532,7 @@ static plist_t restore_get_veridian_firmware_data(restored_client_t restore, str
 	parameters = plist_new_dict();
 
 	/* add manifest for current build_identity to parameters */
-	tss_parameters_add_from_manifest(parameters, build_identity);
+	tss_parameters_add_from_manifest(parameters, build_identity, true);
 
 	/* add BMU,* tags from info dictionary to parameters */
 	plist_dict_merge(&parameters, p_info);
@@ -2628,7 +2628,7 @@ static plist_t restore_get_tcon_firmware_data(restored_client_t restore, struct 
 	parameters = plist_new_dict();
 
 	/* add manifest for current build_identity to parameters */
-	tss_parameters_add_from_manifest(parameters, build_identity);
+	tss_parameters_add_from_manifest(parameters, build_identity, true);
 
 	/* add Baobab,* tags from info dictionary to parameters */
 	plist_dict_merge(&parameters, p_info);
@@ -2701,7 +2701,7 @@ static plist_t restore_get_timer_firmware_data(restored_client_t restore, struct
 	parameters = plist_new_dict();
 
 	/* add manifest for current build_identity to parameters */
-	tss_parameters_add_from_manifest(parameters, build_identity);
+	tss_parameters_add_from_manifest(parameters, build_identity, true);
 
 	plist_dict_set_item(parameters, "ApProductionMode", plist_new_bool(1));
 	if (client->image4supported) {
@@ -2860,6 +2860,64 @@ static plist_t restore_get_timer_firmware_data(restored_client_t restore, struct
 	return response;
 }
 
+static plist_t restore_get_cryptex1_firmware_data(restored_client_t restore, struct idevicerestore_client_t* client, plist_t build_identity, plist_t p_info, plist_t arguments)
+{
+	plist_t parameters = NULL;
+	plist_t request = NULL;
+	plist_t response = NULL;
+	int ret;
+
+	/* create Timer request */
+	request = tss_request_new(NULL);
+	if (request == NULL) {
+		error("ERROR: Unable to create Cryptex1 TSS request\n");
+		return NULL;
+	}
+
+	parameters = plist_new_dict();
+
+	/* add manifest for current build_identity to parameters (Cryptex1 will require the manifest in a seperate message) */
+	tss_parameters_add_from_manifest(parameters, build_identity, false);
+
+	plist_dict_set_item(parameters, "ApProductionMode", plist_new_bool(1));
+	plist_dict_set_item(parameters, "ApSecurityMode", plist_new_bool(1));
+
+	/* add Timer,* tags from info dictionary to parameters */
+	plist_t device_generated_request = plist_dict_get_item(arguments, "DeviceGeneratedRequest");
+	if (!device_generated_request) {
+		error("ERROR: Could not find DeviceGeneratedRequest in arguments dictionary\n");
+		plist_free(parameters);
+		return NULL;
+	} 
+	
+	plist_dict_merge(&parameters, device_generated_request);
+	
+	/* add common tags */
+	tss_request_add_common_tags(request, p_info, NULL);
+
+	/* add Cryptex1 tags */
+	plist_dict_set_item(request, "@BBTicket", plist_new_bool(1));
+	plist_dict_merge(&request, parameters);
+
+	plist_free(parameters);
+
+	info("Sending Cryptex1 TSS request...\n");
+	response = tss_request_send(request, client->tss_url);
+	plist_free(request);
+	if (response == NULL) {
+		error("ERROR: Unable to fetch Cryptex1\n");
+		return NULL;
+	}
+
+	if (plist_dict_get_item(response, "Cryptex1,Ticket")) {
+		info("Received Cryptex1,Ticket\n");
+	} else {
+		error("ERROR: No 'Cryptex1,Ticket' in TSS response, this might not work\n");
+	}
+
+	return response;
+}
+
 static int restore_send_firmware_updater_data(restored_client_t restore, struct idevicerestore_client_t* client, plist_t build_identity, plist_t message)
 {
 	plist_t arguments;
@@ -2959,6 +3017,12 @@ static int restore_send_firmware_updater_data(restored_client_t restore, struct 
 			error("ERROR: %s: Couldn't get AppleTypeCRetimer firmware data\n", __func__);
 			goto error_out;
 		}
+	} else if (strcmp(s_updater_name, "Cryptex1") == 0) {
+		fwdict = restore_get_cryptex1_firmware_data(restore, client, build_identity, p_info, arguments);
+		if (fwdict == NULL) {
+			error("ERROR: %s: Couldn't get AppleTypeCRetimer firmware data\n", __func__);
+			goto error_out;
+		}
 	} else {
 		error("ERROR: %s: Got unknown updater name '%s'.\n", __func__, s_updater_name);
 		goto error_out;
@@ -2987,6 +3051,37 @@ error_out:
 	plist_free(loop_count_dict);
 	return -1;
 }
+
+static int restore_send_receipt_manifest(restored_client_t restore, struct idevicerestore_client_t* client, plist_t build_identity)
+{
+	plist_t dict;
+	int restore_error;
+
+	plist_t manifest = plist_dict_get_item(build_identity, "Manifest");
+	if (!manifest) {
+		error("failed to get Manifest node from build_identity");
+		goto error_out;
+	}
+
+	dict = plist_new_dict();
+	plist_dict_set_item(dict, "ReceiptManifest", plist_copy(manifest));
+
+	info("Sending ReceiptManifest data now...\n");
+	restore_error = restored_send(restore, dict);
+	plist_free(dict);
+	if (restore_error != RESTORE_E_SUCCESS) {
+		error("ERROR: Couldn't send ReceiptManifest data (%d)\n", restore_error);
+		goto error_out;
+	}
+
+	info("Done sending ReceiptManifest data\n");
+
+	return 0;
+
+error_out:
+	return -1;
+}
+
 
 struct cpio_odc_header {
 	char c_magic[6];
@@ -3692,6 +3787,20 @@ int restore_handle_data_request_msg(struct idevicerestore_client_t* client, idev
 			}
 		}
 
+		else if (!strcmp(type, "ReceiptManifest")) {
+			if (restore_send_receipt_manifest(restore, client, build_identity) < 0) {
+				error("ERROR: Unable to send ReceiptManifest data\n");
+				return -1;
+			}
+		}
+
+		else if (!strcmp(type, "BasebandUpdaterOutputData")) {
+			if (restore_handle_baseband_updater_output_data(restore, client, device, message) < 0) {
+				error("ERROR: Unable to send BasebandUpdaterOutputData data\n");
+				return -1;
+			}
+		}
+
 		else {
 			// Unknown DataType!!
 			error("Unknown data request '%s' received\n", type);
@@ -3761,6 +3870,12 @@ plist_t restore_supported_data_types()
 	plist_dict_set_item(dict, "SystemImageRootHash", plist_new_bool(0));
 	plist_dict_set_item(dict, "USBCFWData", plist_new_bool(0));
 	plist_dict_set_item(dict, "USBCOverride", plist_new_bool(0));
+	plist_dict_set_item(dict, "FirmwareUpdaterPreflight", plist_new_bool(1));
+	plist_dict_set_item(dict, "ReceiptManifest", plist_new_bool(1));
+	plist_dict_set_item(dict, "FirmwareUpdaterDataV2", plist_new_bool(0));
+	plist_dict_set_item(dict, "RestoreLocalPolicy", plist_new_bool(1));
+	plist_dict_set_item(dict, "AuthInstallCACert", plist_new_bool(1));
+	plist_dict_set_item(dict, "OverlayRootDataForKeyIndex", plist_new_bool(1));
 	return dict;
 }
 

--- a/src/tss.c
+++ b/src/tss.c
@@ -134,7 +134,7 @@ int tss_request_add_local_policy_tags(plist_t request, plist_t parameters)
 	return 0;
 }
 
-int tss_parameters_add_from_manifest(plist_t parameters, plist_t build_identity)
+int tss_parameters_add_from_manifest(plist_t parameters, plist_t build_identity, bool include_manifest)
 {
 	plist_t node = NULL;
 
@@ -226,13 +226,34 @@ int tss_parameters_add_from_manifest(plist_t parameters, plist_t build_identity)
 	_plist_dict_copy_uint(parameters, build_identity, "Timer,SecurityDomain,1", NULL);
 	_plist_dict_copy_uint(parameters, build_identity, "Timer,SecurityDomain,2", NULL);
 
-	/* add build identity manifest dictionary */
-	node = plist_dict_get_item(build_identity, "Manifest");
-	if (!node || plist_get_node_type(node) != PLIST_DICT) {
-		error("ERROR: Unable to find Manifest node\n");
-		return -1;
+	_plist_dict_copy_item(parameters, build_identity, "Cryptex1,ChipID", NULL);
+	_plist_dict_copy_item(parameters, build_identity, "Cryptex1,Type", NULL);
+	_plist_dict_copy_item(parameters, build_identity, "Cryptex1,SubType", NULL);
+	_plist_dict_copy_item(parameters, build_identity, "Cryptex1,ProductClass", NULL);
+	_plist_dict_copy_item(parameters, build_identity, "Cryptex1,UseProductClass", NULL);
+	_plist_dict_copy_item(parameters, build_identity, "Cryptex1,NonceDomain", NULL);
+	_plist_dict_copy_item(parameters, build_identity, "Cryptex1,Version", NULL);
+	_plist_dict_copy_item(parameters, build_identity, "Cryptex1,PreauthorizationVersion", NULL);
+	_plist_dict_copy_item(parameters, build_identity, "Cryptex1,FakeRoot", NULL);
+	_plist_dict_copy_item(parameters, build_identity, "Cryptex1,SystemOS", NULL);
+	_plist_dict_copy_item(parameters, build_identity, "Cryptex1,SystemVolume", NULL);
+	_plist_dict_copy_item(parameters, build_identity, "Cryptex1,SystemTrustCache", NULL);
+	_plist_dict_copy_item(parameters, build_identity, "Cryptex1,AppOS", NULL);
+	_plist_dict_copy_item(parameters, build_identity, "Cryptex1,AppVolume", NULL);
+	_plist_dict_copy_item(parameters, build_identity, "Cryptex1,AppTrustCache", NULL);
+	_plist_dict_copy_item(parameters, build_identity, "Cryptex1,MobileAssetBrainOS", NULL);
+	_plist_dict_copy_item(parameters, build_identity, "Cryptex1,MobileAssetBrainVolume", NULL);
+	_plist_dict_copy_item(parameters, build_identity, "Cryptex1,MobileAssetBrainTrustCache", NULL);
+
+	if (include_manifest) {
+		/* add build identity manifest dictionary */
+		node = plist_dict_get_item(build_identity, "Manifest");
+		if (!node || plist_get_node_type(node) != PLIST_DICT) {
+			error("ERROR: Unable to find Manifest node\n");
+			return -1;
+		}
+		plist_dict_set_item(parameters, "Manifest", plist_copy(node));
 	}
-	plist_dict_set_item(parameters, "Manifest", plist_copy(node));
 
 	return 0;
 }

--- a/src/tss.h
+++ b/src/tss.h
@@ -29,9 +29,10 @@ extern "C" {
 #endif
 
 #include <plist/plist.h>
+#include <stdbool.h>
 
 /* parameters */
-int tss_parameters_add_from_manifest(plist_t parameters, plist_t build_identity);
+int tss_parameters_add_from_manifest(plist_t parameters, plist_t build_identity, bool include_manifest);
 
 /* request */
 plist_t tss_request_new(plist_t overrides);


### PR DESCRIPTION
There are more than a few memory leaks. We should really add a macro to check return values and clean in the error label (in some future big PR). Moreover, instead of copying everything from the `BuildIdentityTags` I just copied hard-coded keys. This list is subject to change in future versions, but the current code is structured otherwise. What do you think of the current solution?