### PR TITLE
Modify the error prompt to make it easier to locate the problem

### DIFF
--- a/src/asr.c
+++ b/src/asr.c
@@ -320,7 +320,7 @@ int asr_handle_oob_data_request(asr_client_t asr, plist_t packet, FILE* file)
 
 	oob_data = (char*) malloc(oob_length);
 	if (oob_data == NULL) {
-		error("ERROR: Out of memory\n");
+		error("ERROR: %s: Out of memory\n", __func__);
 		return -1;
 	}
 

--- a/src/common.c
+++ b/src/common.c
@@ -203,7 +203,7 @@ int read_file(const char* filename, void** data, size_t* size) {
 
 	buffer = (char*) malloc(length);
 	if (buffer == NULL) {
-		error("ERROR: Out of memory\n");
+		error("ERROR: %s: Out of memory\n", __func__);
 		fclose(file);
 		return -1;
 	}

--- a/src/dfu.c
+++ b/src/dfu.c
@@ -50,7 +50,7 @@ int dfu_client_new(struct idevicerestore_client_t* client)
 		client->dfu = (struct dfu_client_t*)malloc(sizeof(struct dfu_client_t));
 		memset(client->dfu, 0, sizeof(struct dfu_client_t));
 		if (client->dfu == NULL) {
-			error("ERROR: Out of memory\n");
+			error("ERROR: %s: Out of memory\n", __func__);
 			return -1;
 		}
 	}

--- a/src/idevicerestore.c
+++ b/src/idevicerestore.c
@@ -1431,7 +1431,7 @@ struct idevicerestore_client_t* idevicerestore_client_new(void)
 {
 	struct idevicerestore_client_t* client = (struct idevicerestore_client_t*) malloc(sizeof(struct idevicerestore_client_t));
 	if (client == NULL) {
-		error("ERROR: Out of memory\n");
+		error("ERROR: %s: Out of memory\n", __func__);
 		return NULL;
 	}
 	memset(client, '\0', sizeof(struct idevicerestore_client_t));

--- a/src/ipsw.c
+++ b/src/ipsw.c
@@ -307,7 +307,7 @@ ipsw_archive* ipsw_open(const char* ipsw)
 	int err = 0;
 	ipsw_archive* archive = (ipsw_archive*) malloc(sizeof(ipsw_archive));
 	if (archive == NULL) {
-		error("ERROR: Out of memory\n");
+		error("ERROR: %s: Out of memory\n", __func__);
 		return NULL;
 	}
 
@@ -344,7 +344,7 @@ int ipsw_get_file_size(const char* ipsw, const char* infile, uint64_t* size)
 {
 	ipsw_archive* archive = ipsw_open(ipsw);
 	if (archive == NULL) {
-		error("ERROR: Invalid archive\n");
+		error("ERROR: %s: Invalid archive\n", __func__);
 		return -1;
 	}
 
@@ -387,7 +387,7 @@ int ipsw_extract_to_file_with_progress(const char* ipsw, const char* infile, con
 	int ret = 0;
 	ipsw_archive* archive = ipsw_open(ipsw);
 	if (archive == NULL) {
-		error("ERROR: Invalid archive\n");
+		error("ERROR: %s: Invalid archive\n", __func__);
 		return -1;
 	}
 
@@ -580,7 +580,7 @@ int ipsw_extract_to_memory(const char* ipsw, const char* infile, unsigned char**
 	unsigned char* buffer = NULL;
 	ipsw_archive* archive = ipsw_open(ipsw);
 	if (archive == NULL) {
-		error("ERROR: Invalid archive\n");
+		error("ERROR: %s: Invalid archive\n", __func__);
 		return -1;
 	}
 
@@ -610,7 +610,7 @@ int ipsw_extract_to_memory(const char* ipsw, const char* infile, unsigned char**
 		size = zstat.size;
 		buffer = (unsigned char*) malloc(size+1);
 		if (buffer == NULL) {
-			error("ERROR: Out of memory\n");
+			error("ERROR: %s: Out of memory\n", __func__);
 			zip_fclose(zfile);
 			ipsw_close(archive);
 			return -1;
@@ -643,7 +643,7 @@ int ipsw_extract_to_memory(const char* ipsw, const char* infile, unsigned char**
 		size = fst.st_size;
 		buffer = (unsigned char*)malloc(size+1);
 		if (buffer == NULL) {
-			error("ERROR: Out of memory\n");
+			error("ERROR: %s: Out of memory\n", __func__);
 			free(filepath);
 			ipsw_close(archive);
 			return -1;
@@ -796,7 +796,7 @@ int ipsw_list_contents(const char* ipsw, ipsw_list_cb cb, void *ctx)
 
 	ipsw_archive* archive = ipsw_open(ipsw);
 	if (archive == NULL) {
-		error("ERROR: Invalid archive\n");
+		error("ERROR: %s: Invalid archive\n", __func__);
 		return -1;
 	}
 

--- a/src/recovery.c
+++ b/src/recovery.c
@@ -67,7 +67,7 @@ int recovery_client_new(struct idevicerestore_client_t* client)
 	if(client->recovery == NULL) {
 		client->recovery = (struct recovery_client_t*)malloc(sizeof(struct recovery_client_t));
 		if (client->recovery == NULL) {
-			error("ERROR: Out of memory\n");
+			error("ERROR: %s: Out of memory\n", __func__);
 			return -1;
 		}
 		memset(client->recovery, 0, sizeof(struct recovery_client_t));

--- a/src/restore.c
+++ b/src/restore.c
@@ -122,7 +122,7 @@ int restore_client_new(struct idevicerestore_client_t* client)
 {
 	struct restore_client_t* restore = (struct restore_client_t*) malloc(sizeof(struct restore_client_t));
 	if (restore == NULL) {
-		error("ERROR: Out of memory\n");
+		error("ERROR: %s: Out of memory\n", __func__);
 		return -1;
 	}
 
@@ -463,7 +463,7 @@ int restore_open_with_timeout(struct idevicerestore_client_t* client)
 	if(client->restore == NULL) {
 		client->restore = (struct restore_client_t*) malloc(sizeof(struct restore_client_t));
 		if(client->restore == NULL) {
-			error("ERROR: Out of memory\n");
+			error("ERROR: %s: Out of memory\n", __func__);
 			return -1;
 		}
 		memset(client->restore, '\0', sizeof(struct restore_client_t));
@@ -1526,7 +1526,7 @@ static int restore_sign_bbfw(const char* bbfwtmp, plist_t bbtss, const unsigned 
 
 			buffer = (unsigned char*) malloc(zstat.size + 1);
 			if (buffer == NULL) {
-				error("ERROR: Out of memory\n");
+				error("ERROR: %s: Out of memory\n", __func__);
 				goto leave;
 			}
 
@@ -1666,7 +1666,7 @@ static int restore_sign_bbfw(const char* bbfwtmp, plist_t bbtss, const unsigned 
 
 			buffer = (unsigned char*) malloc(zstat.size + 1);
 			if (buffer == NULL) {
-				error("ERROR: Out of memory\n");
+				error("ERROR: %s: Out of memory\n", __func__);
 				goto leave;
 			}
 


### PR DESCRIPTION
Not everyone knows this project very well, so it is important to add the function name in the error prompt, so that we can quickly locate the error. Saving time.