### PR TITLE
Allow the device to brush when the serial number cannot be found

### DIFF
--- a/src/idevicerestore.c
+++ b/src/idevicerestore.c
@@ -1349,10 +1349,7 @@ int idevicerestore_start(struct idevicerestore_client_t* client)
 	// now finally do the magic to put the device into restore mode
 	if (client->mode == MODE_RECOVERY) {
 		if (client->srnm == NULL) {
-			error("ERROR: could not retrieve device serial number. Can't continue.\n");
-			if (delete_fs && filesystem)
-				unlink(filesystem);
-			return -1;
+			info("Could not retrieve device serial number.\n");
 		}
 		if (recovery_enter_restore(client, build_identity) < 0) {
 			error("ERROR: Unable to place device into restore mode\n");

--- a/src/restore.c
+++ b/src/restore.c
@@ -455,8 +455,7 @@ int restore_open_with_timeout(struct idevicerestore_client_t* client)
 	}
 
 	if(client->srnm == NULL) {
-		error("ERROR: no SerialNumber in client data!\n");
-		return -1;
+		info("No SerialNumber in client data!\n");
 	}
 
 	// create our restore client if it doesn't yet exist


### PR DESCRIPTION
Some devices may not have serial numbers.
If these data are not necessary, we can ignore them.