### PR TITLE
Change some repeated error prompts to more detailed mode

### DIFF
--- a/src/asr.c
+++ b/src/asr.c
@@ -320,7 +320,7 @@ int asr_handle_oob_data_request(asr_client_t asr, plist_t packet, FILE* file)
 
 	oob_data = (char*) malloc(oob_length);
 	if (oob_data == NULL) {
-		error("ERROR: Out of memory\n");
+		error("ERROR: %s: Out of memory: size(%" PRIu64 ")\n", __func__, (uint64_t)oob_length);
 		return -1;
 	}
 

--- a/src/common.c
+++ b/src/common.c
@@ -203,7 +203,7 @@ int read_file(const char* filename, void** data, size_t* size) {
 
 	buffer = (char*) malloc(length);
 	if (buffer == NULL) {
-		error("ERROR: Out of memory\n");
+		error("ERROR: %s: Out of memory: size(%" PRIu64 ")\n", __func__, (uint64_t)length);
 		fclose(file);
 		return -1;
 	}

--- a/src/dfu.c
+++ b/src/dfu.c
@@ -48,11 +48,11 @@ int dfu_client_new(struct idevicerestore_client_t* client)
 
 	if (client->dfu == NULL) {
 		client->dfu = (struct dfu_client_t*)malloc(sizeof(struct dfu_client_t));
-		memset(client->dfu, 0, sizeof(struct dfu_client_t));
 		if (client->dfu == NULL) {
-			error("ERROR: Out of memory\n");
+			error("ERROR: %s: Out of memory: size(%" PRIu64 ")\n", __func__, (uint64_t)sizeof(struct dfu_client_t));
 			return -1;
 		}
+		memset(client->dfu, 0, sizeof(struct dfu_client_t));
 	}
 
 	for (i = 1; i <= attempts; i++) {

--- a/src/idevicerestore.c
+++ b/src/idevicerestore.c
@@ -1431,7 +1431,7 @@ struct idevicerestore_client_t* idevicerestore_client_new(void)
 {
 	struct idevicerestore_client_t* client = (struct idevicerestore_client_t*) malloc(sizeof(struct idevicerestore_client_t));
 	if (client == NULL) {
-		error("ERROR: Out of memory\n");
+		error("ERROR: %s: Out of memory: size(%" PRIu64 ")\n", __func__, (uint64_t)sizeof(struct idevicerestore_client_t));
 		return NULL;
 	}
 	memset(client, '\0', sizeof(struct idevicerestore_client_t));

--- a/src/ipsw.c
+++ b/src/ipsw.c
@@ -307,7 +307,7 @@ ipsw_archive* ipsw_open(const char* ipsw)
 	int err = 0;
 	ipsw_archive* archive = (ipsw_archive*) malloc(sizeof(ipsw_archive));
 	if (archive == NULL) {
-		error("ERROR: Out of memory\n");
+		error("ERROR: %s: Out of memory: size(%" PRIu64 ")\n", __func__, (uint64_t)sizeof(ipsw_archive));
 		return NULL;
 	}
 
@@ -610,7 +610,7 @@ int ipsw_extract_to_memory(const char* ipsw, const char* infile, unsigned char**
 		size = zstat.size;
 		buffer = (unsigned char*) malloc(size+1);
 		if (buffer == NULL) {
-			error("ERROR: Out of memory\n");
+			error("ERROR: %s: Out of memory: size(%" PRIu64 ")\n", __func__, (uint64_t)size + 1);
 			zip_fclose(zfile);
 			ipsw_close(archive);
 			return -1;
@@ -643,7 +643,7 @@ int ipsw_extract_to_memory(const char* ipsw, const char* infile, unsigned char**
 		size = fst.st_size;
 		buffer = (unsigned char*)malloc(size+1);
 		if (buffer == NULL) {
-			error("ERROR: Out of memory\n");
+			error("ERROR: %s: Out of memory: size(%" PRIu64 ")\n", __func__, (uint64_t)size + 1);
 			free(filepath);
 			ipsw_close(archive);
 			return -1;

--- a/src/recovery.c
+++ b/src/recovery.c
@@ -67,7 +67,7 @@ int recovery_client_new(struct idevicerestore_client_t* client)
 	if(client->recovery == NULL) {
 		client->recovery = (struct recovery_client_t*)malloc(sizeof(struct recovery_client_t));
 		if (client->recovery == NULL) {
-			error("ERROR: Out of memory\n");
+			error("ERROR: %s: Out of memory: size(%" PRIu64 ")\n", __func__, (uint64_t)sizeof(struct recovery_client_t));
 			return -1;
 		}
 		memset(client->recovery, 0, sizeof(struct recovery_client_t));

--- a/src/restore.c
+++ b/src/restore.c
@@ -122,7 +122,7 @@ int restore_client_new(struct idevicerestore_client_t* client)
 {
 	struct restore_client_t* restore = (struct restore_client_t*) malloc(sizeof(struct restore_client_t));
 	if (restore == NULL) {
-		error("ERROR: Out of memory\n");
+		error("ERROR: %s: Out of memory: size(%" PRIu64 ")\n", __func__, (uint64_t)sizeof(struct restore_client_t));
 		return -1;
 	}
 
@@ -463,7 +463,7 @@ int restore_open_with_timeout(struct idevicerestore_client_t* client)
 	if(client->restore == NULL) {
 		client->restore = (struct restore_client_t*) malloc(sizeof(struct restore_client_t));
 		if(client->restore == NULL) {
-			error("ERROR: Out of memory\n");
+			error("ERROR: %s: Out of memory: size(%" PRIu64 ")\n", __func__, (uint64_t)sizeof(struct restore_client_t));
 			return -1;
 		}
 		memset(client->restore, '\0', sizeof(struct restore_client_t));
@@ -1526,7 +1526,7 @@ static int restore_sign_bbfw(const char* bbfwtmp, plist_t bbtss, const unsigned 
 
 			buffer = (unsigned char*) malloc(zstat.size + 1);
 			if (buffer == NULL) {
-				error("ERROR: Out of memory\n");
+				error("ERROR: %s: Out of memory: size(%" PRIu64 ")\n", __func__, (uint64_t)zstat.size + 1);
 				goto leave;
 			}
 
@@ -1666,7 +1666,7 @@ static int restore_sign_bbfw(const char* bbfwtmp, plist_t bbtss, const unsigned 
 
 			buffer = (unsigned char*) malloc(zstat.size + 1);
 			if (buffer == NULL) {
-				error("ERROR: Out of memory\n");
+				error("ERROR: %s: Out of memory: size(%" PRIu64 ")\n", __func__, (uint64_t)zstat.size + 1);
 				goto leave;
 			}
 


### PR DESCRIPTION
Add a function name Description for a duplicate error prompt.
In this way, we can locate and distinguish errors faster. For example, some large files will fail to allocate.
Fix a memset error.