### PR TITLE
Allow device restore without baseband

### DIFF
--- a/src/restore.c
+++ b/src/restore.c
@@ -862,8 +862,8 @@ static int restore_handle_bb_update_status_msg(restored_client_t client, plist_t
 	plist_get_bool_val(node, &accepted);
 
 	if (!accepted) {
-		error("ERROR: device didn't accept BasebandData\n");
-		return result;
+		info("Device didn't accept BasebandData\n");
+		return 0;
 	}
 
 	uint8_t done = 0;


### PR DESCRIPTION
If the device does not have baseband, we should try to restore it.