### PR TITLE
Don't call realpath if arg1 is NULL(Darwin bug)

### DIFF
--- a/src/ipsw.c
+++ b/src/ipsw.c
@@ -468,12 +468,22 @@ int ipsw_extract_to_file_with_progress(const char* ipsw, const char* infile, con
 		char *filepath = build_path(archive->path, infile);
 		char actual_filepath[PATH_MAX+1];
 		char actual_outfile[PATH_MAX+1];
+		if(filepath == NULL || filepath == (const char *)-1) {
+		    error("ERROR: filepath is NULL\n");
+		    ret = -1;
+		    goto leave;
+		}
 		if (!realpath(filepath, actual_filepath)) {
 			error("ERROR: realpath failed on %s: %s\n", filepath, strerror(errno));
 			ret = -1;
 			goto leave;
 		} else {
 			actual_outfile[0] = '\0';
+			if(outfile == NULL || outfile == (const char *)-1) {
+                		error("ERROR: outfile is NULL\n");
+                		ret = -1;
+                		goto leave;
+			}
 			if (realpath(outfile, actual_outfile) && (strcmp(actual_filepath, actual_outfile) == 0)) {
 				/* files are identical */
 				ret = 0;


### PR DESCRIPTION
On darwin realpath verifies the de referenced arg1 pointer isn't NULL, however if the pointer itself is NULL or -1 the the de reference will cause a crash
```
    #0 0x7ff80e3a84f6 in realpath$DARWIN_EXTSN+0x36 (libsystem_c.dylib:x86_64+0x154f6)
    #1 0x?????? in ipsw_extract_to_file_with_progress+0x70a (thebin+0x???)
    
    #rdi = 0xffffffffffffffff
```
<img width="447" alt="image" src="https://user-images.githubusercontent.com/27748705/180081985-6dc974e2-6e10-4cc7-879e-78f265003efe.png">
It crashes because it can't de reference rdi since rdi is -1.