### PR TITLE
[RFC] reduce memory usage

### DIFF
--- a/src/dfu.c
+++ b/src/dfu.c
@@ -31,6 +31,7 @@
 #include "tss.h"
 #include "recovery.h"
 #include "idevicerestore.h"
+#include "ipsw.h"
 #include "common.h"
 
 static int dfu_progress_callback(irecv_client_t client, const irecv_event_t* event) {
@@ -150,7 +151,7 @@ int dfu_send_component(struct idevicerestore_client_t* client, plist_t build_ide
 			}
 		}
 
-		if (extract_component(client->ipsw, path, &component_data, &component_size) < 0) {
+		if (ipsw_extract_component(client->ipsw, path, &component_data, &component_size) < 0) {
 			error("ERROR: Unable to extract component: %s\n", component);
 			free(path);
 			return -1;
@@ -164,10 +165,10 @@ int dfu_send_component(struct idevicerestore_client_t* client, plist_t build_ide
 
 	if (personalize_component(component, component_data, component_size, tss, &data, &size) < 0) {
 		error("ERROR: Unable to get personalized component: %s\n", component);
-		free(component_data);
+		ipsw_free_component(client->ipsw, component_data, component_size);
 		return -1;
 	}
-	free(component_data);
+	ipsw_free_component(client->ipsw, component_data, component_size);
 	component_data = NULL;
 
 	if (!client->image4supported && client->build_major > 8 && !(client->flags & FLAG_CUSTOM) && !strcmp(component, "iBEC")) {

--- a/src/idevicerestore.c
+++ b/src/idevicerestore.c
@@ -2537,28 +2537,6 @@ int build_manifest_get_identity_count(plist_t build_manifest)
 	return plist_array_get_size(build_identities_array);
 }
 
-int extract_component(const char* ipsw, const char* path, unsigned char** component_data, unsigned int* component_size)
-{
-	char* component_name = NULL;
-	if (!ipsw || !path || !component_data || !component_size) {
-		return -1;
-	}
-
-	component_name = strrchr(path, '/');
-	if (component_name != NULL)
-		component_name++;
-	else
-		component_name = (char*) path;
-
-	info("Extracting %s (%s)...\n", component_name, path);
-	if (ipsw_extract_to_memory(ipsw, path, component_data, component_size) < 0) {
-		error("ERROR: Unable to extract %s from %s\n", component_name, ipsw);
-		return -1;
-	}
-
-	return 0;
-}
-
 int personalize_component(const char *component_name, const unsigned char* component_data, unsigned int component_size, plist_t tss_response, unsigned char** personalized_component, unsigned int* personalized_component_size)
 {
 	unsigned char* component_blob = NULL;

--- a/src/idevicerestore.h
+++ b/src/idevicerestore.h
@@ -112,7 +112,6 @@ int build_identity_check_components_in_ipsw(plist_t build_identity, const char* 
 int build_identity_has_component(plist_t build_identity, const char* component);
 int build_identity_get_component_path(plist_t build_identity, const char* component, char** path);
 int ipsw_extract_filesystem(const char* ipsw, plist_t build_identity, char** filesystem);
-int extract_component(const char* ipsw, const char* path, unsigned char** component_data, unsigned int* component_size);
 int personalize_component(const char *component, const unsigned char* component_data, unsigned int component_size, plist_t tss_response, unsigned char** personalized_component, unsigned int* personalized_component_size);
 int get_preboard_manifest(struct idevicerestore_client_t* client, plist_t build_identity, plist_t* manifest);
 

--- a/src/ipsw.h
+++ b/src/ipsw.h
@@ -54,6 +54,9 @@ int ipsw_download_latest_fw(plist_t version_data, const char* product, const cha
 
 void ipsw_cancel(void);
 
+int ipsw_extract_component(const char* ipsw, const char* path, unsigned char** component_data, unsigned int* component_size);
+int ipsw_free_component(const char* ipsw, char *component_data, unsigned int component_size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/recovery.c
+++ b/src/recovery.c
@@ -32,6 +32,7 @@
 #include "idevicerestore.h"
 #include "tss.h"
 #include "img3.h"
+#include "ipsw.h"
 #include "restore.h"
 #include "recovery.h"
 
@@ -283,7 +284,7 @@ int recovery_send_component(struct idevicerestore_client_t* client, plist_t buil
 
 	unsigned char* component_data = NULL;
 	unsigned int component_size = 0;
-	int ret = extract_component(client->ipsw, path, &component_data, &component_size);
+	int ret = ipsw_extract_component(client->ipsw, path, &component_data, &component_size);
 	free(path);
 	if (ret < 0) {
 		error("ERROR: Unable to extract component: %s\n", component);
@@ -291,7 +292,7 @@ int recovery_send_component(struct idevicerestore_client_t* client, plist_t buil
 	}
 
 	ret = personalize_component(component, component_data, component_size, client->tss, &data, &size);
-	free(component_data);
+	ipsw_free_component(client->ipsw, component_data, component_size);
 	if (ret < 0) {
 		error("ERROR: Unable to get personalized component: %s\n", component);
 		return -1;

--- a/src/restore.c
+++ b/src/restore.c
@@ -1068,7 +1068,7 @@ int restore_send_component(restored_client_t restore, struct idevicerestore_clie
 
 	unsigned char* component_data = NULL;
 	unsigned int component_size = 0;
-	int ret = extract_component(client->ipsw, path, &component_data, &component_size);
+	int ret = ipsw_extract_component(client->ipsw, path, &component_data, &component_size);
 	free(path);
 	path = NULL;
 	if (ret < 0) {
@@ -1077,7 +1077,7 @@ int restore_send_component(restored_client_t restore, struct idevicerestore_clie
 	}
 
 	ret = personalize_component(component, component_data, component_size, client->tss, &data, &size);
-	free(component_data);
+	ipsw_free_component(client->ipsw, component_data, component_size);
 	component_data = NULL;
 	if (ret < 0) {
 		error("ERROR: Unable to get personalized component %s\n", component);
@@ -1229,7 +1229,7 @@ int restore_send_nor(restored_client_t restore, struct idevicerestore_client_t* 
 	const char* component = "LLB";
 	unsigned char* component_data = NULL;
 	unsigned int component_size = 0;
-	int ret = extract_component(client->ipsw, llb_path, &component_data, &component_size);
+	int ret = ipsw_extract_component(client->ipsw, llb_path, &component_data, &component_size);
 	free(llb_path);
 	if (ret < 0) {
 		error("ERROR: Unable to extract component: %s\n", component);
@@ -1237,7 +1237,7 @@ int restore_send_nor(restored_client_t restore, struct idevicerestore_client_t* 
 	}
 
 	ret = personalize_component(component, component_data, component_size, client->tss, &llb_data, &llb_size);
-	free(component_data);
+	ipsw_free_component(client->ipsw, component_data, component_size);
 	component_data = NULL;
 	component_size = 0;
 	if (ret < 0) {
@@ -1283,7 +1283,7 @@ int restore_send_nor(restored_client_t restore, struct idevicerestore_client_t* 
 		component_data = NULL;
 		unsigned int component_size = 0;
 
-		if (extract_component(client->ipsw, comppath, &component_data, &component_size) < 0) {
+		if (ipsw_extract_component(client->ipsw, comppath, &component_data, &component_size) < 0) {
 			free(iter);
 			free(comp);
 			free(comppath);
@@ -1301,7 +1301,7 @@ int restore_send_nor(restored_client_t restore, struct idevicerestore_client_t* 
 			error("ERROR: Unable to get personalized component: %s\n", component);
 			return -1;
 		}
-		free(component_data);
+		ipsw_free_component(client->ipsw, component_data, component_size);
 		component_data = NULL;
 		component_size = 0;
 
@@ -1332,7 +1332,7 @@ int restore_send_nor(restored_client_t restore, struct idevicerestore_client_t* 
 	if (build_identity_has_component(build_identity, "RestoreSEP") &&
 	    build_identity_get_component_path(build_identity, "RestoreSEP", &restore_sep_path) == 0) {
 		component = "RestoreSEP";
-		ret = extract_component(client->ipsw, restore_sep_path, &component_data, &component_size);
+		ret = ipsw_extract_component(client->ipsw, restore_sep_path, &component_data, &component_size);
 		free(restore_sep_path);
 		if (ret < 0) {
 			error("ERROR: Unable to extract component: %s\n", component);
@@ -1340,7 +1340,7 @@ int restore_send_nor(restored_client_t restore, struct idevicerestore_client_t* 
 		}
 
 		ret = personalize_component(component, component_data, component_size, client->tss, &personalized_data, &personalized_size);
-		free(component_data);
+		ipsw_free_component(client->ipsw, component_data, component_size);
 		component_data = NULL;
 		component_size = 0;
 		if (ret < 0) {
@@ -1357,7 +1357,7 @@ int restore_send_nor(restored_client_t restore, struct idevicerestore_client_t* 
 	if (build_identity_has_component(build_identity, "SEP") &&
 	    build_identity_get_component_path(build_identity, "SEP", &sep_path) == 0) {
 		component = "SEP";
-		ret = extract_component(client->ipsw, sep_path, &component_data, &component_size);
+		ret = ipsw_extract_component(client->ipsw, sep_path, &component_data, &component_size);
 		free(sep_path);
 		if (ret < 0) {
 			error("ERROR: Unable to extract component: %s\n", component);
@@ -1365,7 +1365,7 @@ int restore_send_nor(restored_client_t restore, struct idevicerestore_client_t* 
 		}
 
 		ret = personalize_component(component, component_data, component_size, client->tss, &personalized_data, &personalized_size);
-		free(component_data);
+		ipsw_free_component(client->ipsw, component_data, component_size);
 		component_data = NULL;
 		component_size = 0;
 		if (ret < 0) {
@@ -2035,7 +2035,7 @@ static int restore_send_image_data(restored_client_t restore, struct idevicerest
 						}
 						build_identity_get_component_path(build_identity, component, &path);
 						if (path) {
-							ret = extract_component(client->ipsw, path, &component_data, &component_size);
+							ret = ipsw_extract_component(client->ipsw, path, &component_data, &component_size);
 						}
 						free(path);
 						path = NULL;
@@ -2044,7 +2044,7 @@ static int restore_send_image_data(restored_client_t restore, struct idevicerest
 						}
 
 						ret = personalize_component(component, component_data, component_size, client->tss, &data, &size);
-						free(component_data);
+						ipsw_free_component(client->ipsw, component_data, component_size);
 						component_data = NULL;
 						if (ret < 0) {
 							error("ERROR: Unable to get personalized component: %s\n", component);
@@ -2142,7 +2142,7 @@ static plist_t restore_get_se_firmware_data(restored_client_t restore, struct id
 		return NULL;
 	}
 
-	ret = extract_component(client->ipsw, comp_path, &component_data, &component_size);
+	ret = ipsw_extract_component(client->ipsw, comp_path, &component_data, &component_size);
 	free(comp_path);
 	comp_path = NULL;
 	if (ret < 0) {
@@ -2187,7 +2187,7 @@ static plist_t restore_get_se_firmware_data(restored_client_t restore, struct id
 	}
 
 	plist_dict_set_item(response, "FirmwareData", plist_new_data((char*)component_data, (uint64_t) component_size));
-	free(component_data);
+	ipsw_free_component(client->ipsw, component_data, component_size);
 	component_data = NULL;
 	component_size = 0;
 
@@ -2255,7 +2255,7 @@ static plist_t restore_get_savage_firmware_data(restored_client_t restore, struc
 		return NULL;
 	}
 
-	ret = extract_component(client->ipsw, comp_path, &component_data, &component_size);
+	ret = ipsw_extract_component(client->ipsw, comp_path, &component_data, &component_size);
 	free(comp_path);
 	comp_path = NULL;
 	if (ret < 0) {
@@ -2278,7 +2278,7 @@ static plist_t restore_get_savage_firmware_data(restored_client_t restore, struc
 	component_size += 16;
 
 	plist_dict_set_item(response, "FirmwareData", plist_new_data((char*)component_data, (uint64_t) component_size));
-	free(component_data);
+	ipsw_free_component(client->ipsw, component_data, component_size);
 	component_data = NULL;
 	component_size = 0;
 
@@ -2347,7 +2347,7 @@ static plist_t restore_get_yonkers_firmware_data(restored_client_t restore, stru
 	}
 
 	/* now get actual component data */
-	ret = extract_component(client->ipsw, comp_path, &component_data, &component_size);
+	ret = ipsw_extract_component(client->ipsw, comp_path, &component_data, &component_size);
 	free(comp_path);
 	comp_path = NULL;
 	if (ret < 0) {
@@ -2362,7 +2362,7 @@ static plist_t restore_get_yonkers_firmware_data(restored_client_t restore, stru
 	plist_dict_set_item(firmware_data, "YonkersFirmware", plist_new_data((char *)component_data, (uint64_t)component_size));
 	plist_dict_set_item(response, "FirmwareData", firmware_data);
 
-	free(component_data);
+	ipsw_free_component(client->ipsw, component_data, component_size);
 	component_data = NULL;
 	component_size = 0;
 
@@ -2432,7 +2432,7 @@ static plist_t restore_get_rose_firmware_data(restored_client_t restore, struct 
 		error("ERROR: Unable to get path for '%s' component\n", comp_name);
 		return NULL;
 	}
-	ret = extract_component(client->ipsw, comp_path, &component_data, &component_size);
+	ret = ipsw_extract_component(client->ipsw, comp_path, &component_data, &component_size);
 	free(comp_path);
 	comp_path = NULL;
 	if (ret < 0) {
@@ -2444,7 +2444,7 @@ static plist_t restore_get_rose_firmware_data(restored_client_t restore, struct 
 		error("ERROR: Failed to parse '%s' component data.\n", comp_name);
 		return NULL;
 	}
-	free(component_data);
+	ipsw_free_component(client->ipsw, component_data, component_size);
 	component_data = NULL;
 	component_size = 0;
 	if (ftag != 'rkos') {
@@ -2458,7 +2458,7 @@ static plist_t restore_get_rose_firmware_data(restored_client_t restore, struct 
 			error("ERROR: Unable to get path for '%s' component\n", comp_name);
 			return NULL;
 		}
-		ret = extract_component(client->ipsw, comp_path, &component_data, &component_size);
+		ret = ipsw_extract_component(client->ipsw, comp_path, &component_data, &component_size);
 		free(comp_path);
 		comp_path = NULL;
 		if (ret < 0) {
@@ -2474,7 +2474,7 @@ static plist_t restore_get_rose_firmware_data(restored_client_t restore, struct 
 			error("ERROR: Failed to parse '%s' component data.\n", comp_name);
 			return NULL;
 		}
-		free(component_data);
+		ipsw_free_component(client->ipsw, component_data, component_size);
 		component_data = NULL;
 		component_size = 0;
 		if (ftag != 'rkos') {
@@ -2557,7 +2557,7 @@ static plist_t restore_get_veridian_firmware_data(restored_client_t restore, str
 	}
 
 	/* now get actual component data */
-	ret = extract_component(client->ipsw, comp_path, &component_data, &component_size);
+	ret = ipsw_extract_component(client->ipsw, comp_path, &component_data, &component_size);
 	free(comp_path);
 	comp_path = NULL;
 	if (ret < 0) {
@@ -2571,7 +2571,7 @@ static plist_t restore_get_veridian_firmware_data(restored_client_t restore, str
 	} else {
 		plist_from_xml((const char*)component_data, component_size, &fw_map);
 	}
-	free(component_data);
+	ipsw_free_component(client->ipsw, component_data, component_size);
 	component_data = NULL;
 	component_size = 0;
 
@@ -2653,7 +2653,7 @@ static plist_t restore_get_tcon_firmware_data(restored_client_t restore, struct 
 	}
 
 	/* now get actual component data */
-	ret = extract_component(client->ipsw, comp_path, &component_data, &component_size);
+	ret = ipsw_extract_component(client->ipsw, comp_path, &component_data, &component_size);
 	free(comp_path);
 	comp_path = NULL;
 	if (ret < 0) {
@@ -2662,7 +2662,7 @@ static plist_t restore_get_tcon_firmware_data(restored_client_t restore, struct 
 	}
 
 	plist_dict_set_item(response, "FirmwareData", plist_new_data((char *)component_data, (uint64_t)component_size));
-	free(component_data);
+	ipsw_free_component(client->ipsw, component_data, component_size);
 	component_data = NULL;
 	component_size = 0;
 
@@ -2779,7 +2779,7 @@ static plist_t restore_get_timer_firmware_data(restored_client_t restore, struct
 			error("ERROR: Unable to get path for '%s' component\n", comp_name);
 			return NULL;
 		}
-		ret = extract_component(client->ipsw, comp_path, &component_data, &component_size);
+		ret = ipsw_extract_component(client->ipsw, comp_path, &component_data, &component_size);
 		free(comp_path);
 		comp_path = NULL;
 		if (ret < 0) {
@@ -2791,7 +2791,7 @@ static plist_t restore_get_timer_firmware_data(restored_client_t restore, struct
 			error("ERROR: Failed to parse '%s' component data.\n", comp_name);
 			return NULL;
 		}
-		free(component_data);
+		ipsw_free_component(client->ipsw, component_data, component_size);
 		component_data = NULL;
 		component_size = 0;
 		if (ftag != 'rkos') {
@@ -2808,7 +2808,7 @@ static plist_t restore_get_timer_firmware_data(restored_client_t restore, struct
 			error("ERROR: Unable to get path for '%s' component\n", comp_name);
 			return NULL;
 		}
-		ret = extract_component(client->ipsw, comp_path, &component_data, &component_size);
+		ret = ipsw_extract_component(client->ipsw, comp_path, &component_data, &component_size);
 		free(comp_path);
 		comp_path = NULL;
 		if (ret < 0) {
@@ -2824,7 +2824,7 @@ static plist_t restore_get_timer_firmware_data(restored_client_t restore, struct
 			error("ERROR: Failed to parse '%s' component data.\n", comp_name);
 			return NULL;
 		}
-		free(component_data);
+		ipsw_free_component(client->ipsw, component_data, component_size);
 		component_data = NULL;
 		component_size = 0;
 		if (ftag != 'rkos') {
@@ -3400,7 +3400,7 @@ int restore_send_personalized_boot_object_v3(restored_client_t restore, struct i
 		// Extract component
 		unsigned char *component_data = NULL;
 		unsigned int component_size = 0;
-		int ret = extract_component(client->ipsw, path, &component_data, &component_size);
+		int ret = ipsw_extract_component(client->ipsw, path, &component_data, &component_size);
 		free(path);
 		path = NULL;
 		if (ret < 0) {
@@ -3410,7 +3410,7 @@ int restore_send_personalized_boot_object_v3(restored_client_t restore, struct i
 
 		// Personalize IMG40
 		ret = personalize_component(component, component_data, component_size, client->tss, &data, &size);
-		free(component_data);
+		ipsw_free_component(client->ipsw, component_data, component_size);
 		component_data = NULL;
 		if (ret < 0) {
 			error("ERROR: Unable to get personalized component %s\n", component);
@@ -3519,7 +3519,7 @@ int restore_send_source_boot_object_v4(restored_client_t restore, struct idevice
 			}
 		}
 
-		int ret = extract_component(client->ipsw, path, &data, &size);
+		int ret = ipsw_extract_component(client->ipsw, path, &data, &size);
 		free(path);
 		path = NULL;
 		if (ret < 0) {
@@ -3562,7 +3562,7 @@ int restore_send_source_boot_object_v4(restored_client_t restore, struct idevice
 	}
 
 	plist_free(dict);
-	free(data);
+	ipsw_free_component(client->ipsw, data, size);
 
 	info("Done sending %s\n", component_name);
 	return 0;


### PR DESCRIPTION
Hi,

This is a change to reduce idevicerestore's runtime memory usage to make the tool more friendly with low-memory machine (targeting ones with 512MB or more). I have only tested on Linux and macOS IPSW and not tested with any other *OS variants, so marked as RFC for asking comments or feedback.

#### Testing
host: Linux (x86_64) with swap disabled
ipsw: UniversalMac_13.0_22A5321d_Restore (fully extracted)
device: Macmini9,1

Ran idevicerestore with or without the patch inside a memory cgroup (v1) to limit its memory usage.

- With the patch
  - With memory.limit_in_bytes=469762048 (448MiB): restore succeeded
  - With memory.limit_in_bytes=402653184 (384MiB): restore succeeded
  - With memory.limit_in_bytes=268435456 (256MiB): OOM killed
```
$ time sudo idevicerestore --no-input --erase UniversalMac_13.0_22A5321d_Restore
...
Extracting 078-20439-069.dmg.mtree (Firmware/078-20439-069.dmg.mtree)...
Personalizing IMG4 component Ap,SystemVolumeCanonicalMetadata...
Sending IsFUDFirmware for Ap,SystemVolumeCanonicalMetadata...
Killed
```

- Without the patch
  - With memory.limit_in_bytes=5368709120 (5GiB): restore succeeded 
  - With memory.limit_in_bytes=4294967296 (4GiB): OOM killed
 ```
$ time sudo idevicerestore --no-input --erase UniversalMac_13.0_22A5321d_Restore
...
</dict>
</plist>
About to send Cryptex1,SystemOS...
common.c:printing 0 bytes plist:
(null)Extracting 078-37309-059.dmg (078-37309-059.dmg)...
Killed
```  
Also tested with an actual x86_64 machine with 1GB memory without swap and restore succeeded.

Note that other variant of IPSW or even different version of macOS may need more or less memory, just depending on contents in the IPSW.

#### Notes
- macOS build is only tested on macOS 13 beta7 (22A5342f)
- win32 still uses malloc and fread as mmap isn't available
  - Assuming [file mapping object](https://docs.microsoft.com/en-us/windows/win32/memory/file-mapping) is equivalent, but I currently don't have a good Windows machine to test
- Not tested with other IPSW variants such as iOS and I don't have other Apple devices
- With Linux on actual low-memory machine, sysctl `vm.overcommit_memory` would need to be set to 1.
- Not sure if you like the way to check if an IPSW is zipped at \*free\*ing component

Any feedback would be appreciated.

Thanks,
Munehisa