### PR TITLE
fix bootx issue in macOS 13

### DIFF
--- a/src/recovery.c
+++ b/src/recovery.c
@@ -498,7 +498,7 @@ int recovery_send_kernelcache(struct idevicerestore_client_t* client, plist_t bu
 		recovery_error = irecv_send_command(client->recovery->client, setba);
 	}
 
-	recovery_error = irecv_send_command(client->recovery->client, "bootx");
+	recovery_error = irecv_send_command_breq(client->recovery->client, "bootx", client->macos_variant ? 1 : 0);
 	if (recovery_error != IRECV_E_SUCCESS) {
 		error("ERROR: Unable to execute %s\n", component);
 		return -1;


### PR DESCRIPTION
As reported in https://github.com/libimobiledevice/idevicerestore/issues/535, bootx command fails with the few recent macOS 13 IPSWs. This trivial patch should fix the issue.

I tested the patch with the following IPSWs on Macmini9,1 and restore succeeded with all of them. macOS 13 beta 7 and macOS 12.6 were picked up for minimal backward-compatibility testing.

- UniversalMac_12.6_21G115_Restore.ipsw
- UniversalMac_13.0_22A5342f_Restore.ipsw (macOS 13 beta 7)
- UniversalMac_13.0_22A5352e_Restore.ipsw (macOS 13 beta 8)
- UniversalMac_13.0_22A5358e_Restore.ipsw (macOS 13 beta 9)
- UniversalMac_13.0_22A5365d_Restore.ipsw (macOS 13 beta 10)

Without the patch, restore fails with macOS 13 beta 8 IPSW or newer as the device can't enter restore mode from recovery mode.

Thanks,
Munehisa