### PR TITLE
Add docker scripts to simplify setting up idevicerestore

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -304,3 +304,16 @@ jobs:
       with:
         name: idevicerestore-latest_${{ matrix.arch }}-${{ env.dest }}
         path: idevicerestore.tar
+  build-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: build
+        run: |
+          pushd docker && ./build.sh; popd
+          docker image save -o idevicerestore-docker.tar idevicerestore-docker
+      - name: publish artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: idevicerestore-latest_docker
+          path: idevicerestore-docker.tar

--- a/README.md
+++ b/README.md
@@ -262,9 +262,12 @@ man idevicerestore
 
 ### Docker
 
-Execute `run.sh --latest` in the docker folder,
-which will build a docker container with the latest source versions of all required libraries,
-and then will execute `usbmuxd` in the background, and then start `idevicerestore --latest`.
+Build the container with `build.sh` in the docker folder, which will build a
+docker container with the latest source versions of all the required libraries.
+
+Run the container with `run.sh --latest` in the docker folder,
+which will execute `usbmuxd` in the background, and then start `idevicerestore --latest`.
+Any arguments passed to `run.sh` will be passed in to `idevicerestore`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ and then will execute `idevicerestore --latest`
 
 After running the script once, the container can be reused with:
 ```shell
-docker run -it --privileged -v "$(pwd):/tmp" idevicerestore-docker idevicerestore [optional commandline args]
+docker run -it --privileged --net=host -v /run/udev/control:/run/udev/control -v "$(pwd):/tmp" idevicerestore-docker idevicerestore [optional commandline args]
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -260,6 +260,17 @@ idevicerestore --help
 man idevicerestore
 ```
 
+### Docker
+
+Execute `run.sh` in the docker folder,
+which will build a docker container with the latest source versions of all required libraries,
+and then will execute `idevicerestore --latest`
+
+After running the script once, the container can be reused with:
+```shell
+docker run -it --privileged -v "$(pwd):/tmp" idevicerestore-docker idevicerestore [optional commandline args]
+```
+
 ## Contributing
 
 We welcome contributions from anyone and are grateful for every pull request!

--- a/README.md
+++ b/README.md
@@ -262,14 +262,9 @@ man idevicerestore
 
 ### Docker
 
-Execute `run.sh` in the docker folder,
+Execute `run.sh --latest` in the docker folder,
 which will build a docker container with the latest source versions of all required libraries,
-and then will execute `idevicerestore --latest`
-
-After running the script once, the container can be reused with:
-```shell
-docker run -it --privileged --net=host -v /run/udev/control:/run/udev/control -v "$(pwd):/tmp" idevicerestore-docker idevicerestore [optional commandline args]
-```
+and then will execute `usbmuxd` in the background, and then start `idevicerestore --latest`.
 
 ## Contributing
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,20 +2,21 @@ FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND="noninteractive"
 RUN apt-get update && apt-get install -y \
-	build-essential \
-	pkg-config \
-	checkinstall \
-	git \
-	autoconf \
-	automake \
-	libtool-bin \
-	libreadline-dev \
-	libusb-1.0-0-dev \
-	libcurl4-openssl-dev \
-	libssl-dev \
-	libzip-dev \
-	zlib1g-dev \
-        python3
+    build-essential \
+    pkg-config \
+    checkinstall \
+    git \
+    autoconf \
+    automake \
+    libtool-bin \
+    libreadline-dev \
+    libusb-1.0-0-dev \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    libzip-dev \
+    zlib1g-dev \
+    python3 \
+    udev
 
 RUN git clone https://github.com/libimobiledevice/libplist.git && \
     cd libplist && \
@@ -57,8 +58,6 @@ RUN git clone https://github.com/libimobiledevice/libimobiledevice.git && \
     cd .. && \
     rm libimobiledevice -rf
 
-
-
 RUN git clone https://github.com/libimobiledevice/libirecovery.git && \
     cd libirecovery && \
     ./autogen.sh && \
@@ -66,6 +65,14 @@ RUN git clone https://github.com/libimobiledevice/libirecovery.git && \
     make install && \
     cd .. && \
     rm libirecovery -rf
+
+RUN git clone https://github.com/libimobiledevice/usbmuxd.git  && \
+    cd usbmuxd && \
+    ./autogen.sh && \
+    make && \
+    make install && \
+    cd .. && \
+    rm usbmuxd -rf
 
 RUN git clone https://github.com/libimobiledevice/idevicerestore.git && \
     cd idevicerestore && \
@@ -77,4 +84,6 @@ RUN git clone https://github.com/libimobiledevice/idevicerestore.git && \
 
 RUN ldconfig
 WORKDIR /tmp
-CMD idevicerestore
+COPY idevicerestore.sh /usr/sbin/idevicerestore.sh
+CMD idevicerestore.sh
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND="noninteractive"
 RUN apt-get update && apt-get install -y \
 	build-essential \
 	pkg-config \
@@ -13,8 +15,7 @@ RUN apt-get update && apt-get install -y \
 	libssl-dev \
 	libzip-dev \
 	zlib1g-dev \
-    python3 \
-    cython
+        python3
 
 RUN git clone https://github.com/libimobiledevice/libplist.git && \
     cd libplist && \
@@ -23,6 +24,14 @@ RUN git clone https://github.com/libimobiledevice/libplist.git && \
     make install && \
     cd .. && \
     rm libplist -rf
+
+RUN git clone https://github.com/libimobiledevice/libtatsu.git && \
+    cd libtatsu && \
+    ./autogen.sh && \
+    make && \
+    make install && \
+    cd .. && \
+    rm libtatsu -rf
 
 RUN git clone https://github.com/libimobiledevice/libimobiledevice-glue.git && \
     cd libimobiledevice-glue && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,71 @@
+FROM ubuntu:18.04
+RUN apt-get update && apt-get install -y \
+	build-essential \
+	pkg-config \
+	checkinstall \
+	git \
+	autoconf \
+	automake \
+	libtool-bin \
+	libreadline-dev \
+	libusb-1.0-0-dev \
+	libcurl4-openssl-dev \
+	libssl-dev \
+	libzip-dev \
+	zlib1g-dev \
+    python3 \
+    cython
+
+RUN git clone https://github.com/libimobiledevice/libplist.git && \
+    cd libplist && \
+    ./autogen.sh && \
+    make && \
+    make install && \
+    cd .. && \
+    rm libplist -rf
+
+RUN git clone https://github.com/libimobiledevice/libimobiledevice-glue.git && \
+    cd libimobiledevice-glue && \
+    ./autogen.sh && \
+    make && \
+    make install && \
+    cd .. && \
+    rm libimobiledevice-glue -rf
+
+RUN git clone https://github.com/libimobiledevice/libusbmuxd.git && \
+    cd libusbmuxd && \
+    ./autogen.sh && \
+    make && \
+    make install && \
+    cd .. && \
+    rm libusbmuxd -rf
+
+RUN git clone https://github.com/libimobiledevice/libimobiledevice.git && \
+    cd libimobiledevice && \
+    ./autogen.sh && \
+    make && \
+    make install && \
+    cd .. && \
+    rm libimobiledevice -rf
+
+
+
+RUN git clone https://github.com/libimobiledevice/libirecovery.git && \
+    cd libirecovery && \
+    ./autogen.sh && \
+    make && \
+    make install && \
+    cd .. && \
+    rm libirecovery -rf
+
+RUN git clone https://github.com/libimobiledevice/idevicerestore.git && \
+    cd idevicerestore && \
+    ./autogen.sh && \
+    make && \
+    make install && \
+    cd .. && \
+    rm idevicerestore -rf
+
+RUN ldconfig
+WORKDIR /tmp
+CMD idevicerestore

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND="noninteractive"
 RUN apt-get update && apt-get install -y \

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+cd "$(dirname "$0")"
+
+docker build . -t idevicerestore-docker --no-cache
+
+echo "You can now use 'run.sh --latest' to run the restore."
+

--- a/docker/idevicerestore.sh
+++ b/docker/idevicerestore.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+usbmuxd &
+
+idevicerestore "$@"
+

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cd "$(dirname "$0")"
+
+docker build . -t idevicerestore-docker
+docker run -it --privileged -v "$(pwd):/tmp" idevicerestore-docker idevicerestore --latest

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -3,4 +3,7 @@ set -e
 cd "$(dirname "$0")"
 
 docker build . -t idevicerestore-docker
-docker run -it --privileged --net=host -v /run/udev/control:/run/udev/control -v "$(pwd):/tmp" idevicerestore-docker idevicerestore --latest
+docker rm --force idevicerestore || true
+
+docker run --name idevicerestore -it --privileged --net=host -v /dev:/dev -v /run/udev/control:/run/udev/control -v "$(pwd):/tmp" idevicerestore-docker idevicerestore.sh "$@"
+

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 cd "$(dirname "$0")"
 
 docker build . -t idevicerestore-docker

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -3,4 +3,4 @@ set -e
 cd "$(dirname "$0")"
 
 docker build . -t idevicerestore-docker
-docker run -it --privileged -v "$(pwd):/tmp" idevicerestore-docker idevicerestore --latest
+docker run -it --privileged --net=host -v /run/udev/control:/run/udev/control -v "$(pwd):/tmp" idevicerestore-docker idevicerestore --latest

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -2,7 +2,11 @@
 set -e
 cd "$(dirname "$0")"
 
-docker build . -t idevicerestore-docker
+if [[ -z $(docker images | grep idevicerestore-docker) ]]; then
+    echo "Container not built, you will need to build it with 'build.sh'"
+    exit -1
+fi
+
 docker rm --force idevicerestore || true
 
 docker run --name idevicerestore -it --privileged --net=host -v /dev:/dev -v /run/udev/control:/run/udev/control -v "$(pwd):/tmp" idevicerestore-docker idevicerestore.sh "$@"


### PR DESCRIPTION
This makes it easier to setup `idevicerestore` with all the latest libmobiledevice libraries.

I have not tested this through a full restore, but it does detect my device (which is as far as I got following the official instructions anyway)

Example output:

```
❯ ./docker/run.sh
Sending build context to Docker daemon  4.096kB
Step 1/11 : FROM ubuntu:18.04
 ---> e28a50f651f9
Step 2/11 : RUN apt-get update && apt-get install -y 	build-essential 	pkg-config 	checkinstall 	git 	autoconf 	automake 	libtool-bin 	libreadline-dev 	libusb-1.0-0-dev 	libcurl4-openssl-dev 	libssl-dev 	libzip-dev 	zlib1g-dev     python3     cython
 ---> Using cache
 ---> f4f246aec778
Step 3/11 : RUN git clone https://github.com/libimobiledevice/libplist.git &&     cd libplist &&     ./autogen.sh &&     make &&     make install &&     cd .. &&     rm libplist -rf
 ---> Using cache
 ---> bde5605a4e79
Step 4/11 : RUN git clone https://github.com/libimobiledevice/libimobiledevice-glue.git &&     cd libimobiledevice-glue &&     ./autogen.sh &&     make &&     make install &&     cd .. &&     rm libimobiledevice-glue -rf
 ---> Using cache
 ---> a18f0f0d312f
Step 5/11 : RUN git clone https://github.com/libimobiledevice/libusbmuxd.git &&     cd libusbmuxd &&     ./autogen.sh &&     make &&     make install &&     cd .. &&     rm libusbmuxd -rf
 ---> Using cache
 ---> 7487aaf95ef8
Step 6/11 : RUN git clone https://github.com/libimobiledevice/libimobiledevice.git &&     cd libimobiledevice &&     ./autogen.sh &&     make &&     make install &&     cd .. &&     rm libimobiledevice -rf
 ---> Using cache
 ---> d9914575dc50
Step 7/11 : RUN git clone https://github.com/libimobiledevice/libirecovery.git &&     cd libirecovery &&     ./autogen.sh &&     make &&     make install &&     cd .. &&     rm libirecovery -rf
 ---> Using cache
 ---> c3a4e07b521f
Step 8/11 : RUN git clone https://github.com/libimobiledevice/idevicerestore.git &&     cd idevicerestore &&     ./autogen.sh &&     make &&     make install &&     cd .. &&     rm idevicerestore -rf
 ---> Using cache
 ---> 2c151c072140
Step 9/11 : RUN ldconfig
 ---> Using cache
 ---> c9890a92e34b
Step 10/11 : WORKDIR /tmp
 ---> Using cache
 ---> f5aa930da9b3
Step 11/11 : CMD idevicerestore
 ---> Using cache
 ---> bd1c899c82a3
Successfully built bd1c899c82a3
Successfully tagged idevicerestore-docker:latest
idevicerestore 1.0.0-128-g7b89019
Found device in DFU mode
ECID: 5991944144224286
Identified device as j313ap, MacBookAir10,1
The following firmwares are currently being signed for MacBookAir10,1:
  [1] 13.2 (build 22D49)
...
  [27] 11.0.1 (build 20B29)
Select the firmware you want to restore: 
```