### PR TITLE
Add support for mac mini m2 pro

### DIFF
--- a/src/dfu.c
+++ b/src/dfu.c
@@ -349,11 +349,13 @@ int dfu_send_iboot_stage1_components(struct idevicerestore_client_t* client, pli
 			uint8_t b = 0;
 			plist_get_bool_val(iboot_node, &b);
 			if (b) {
-				debug("DEBUG: %s is loaded by iBoot Stage 1.\n", key);
-				if (dfu_send_component_and_command(client, build_identity, key, "firmware") < 0) {
-					error("ERROR: Unable to send component '%s' to device.\n", key);
-					err++;
-				}
+				debug("DEBUG: %s is loaded by iBoot Stage 1 and iBoot.\n", key);
+			} else {
+				debug("DEBUG: %s is loaded by iBoot Stage 1 but not iBoot...\n", key);
+			}
+			if (dfu_send_component_and_command(client, build_identity, key, "firmware") < 0) {
+				error("ERROR: Unable to send component '%s' to device.\n", key);
+				err++;
 			}
 		}
 		free(key);

--- a/src/dfu.c
+++ b/src/dfu.c
@@ -473,6 +473,21 @@ int dfu_enter_recovery(struct idevicerestore_client_t* client, plist_t build_ide
 				return -1;
 			}
 
+			char *value = NULL;
+			unsigned long boot_stage = 0;
+			irecv_getenv(client->dfu->client, "boot-stage", &value);
+			if (value) {
+				boot_stage = strtoul(value, NULL, 0);
+			}
+			if (boot_stage > 0) {
+				info("iBoot boot-stage=%s\n", value);
+				free(value);
+				value = NULL;
+				if (boot_stage != 1) {
+					error("ERROR: iBoot should be at boot stage 1, continuing anyway...\n");
+				}
+			}
+
 			if (dfu_send_iboot_stage1_components(client, build_identity) < 0) {
 				mutex_unlock(&client->device_event_mutex);
 				error("ERROR: Unable to send iBoot stage 1 components to device\n");

--- a/src/recovery.c
+++ b/src/recovery.c
@@ -158,6 +158,20 @@ int recovery_enter_restore(struct idevicerestore_client_t* client, plist_t build
 	free(value);
 	value = NULL;
 
+	unsigned long boot_stage = 0;
+	irecv_getenv(client->recovery->client, "boot-stage", &value);
+	if (value) {
+		boot_stage = strtoul(value, NULL, 0);
+	}
+	if (boot_stage > 0) {
+		info("iBoot boot-stage=%s\n", value);
+		free(value);
+		value = NULL;
+		if (boot_stage != 2) {
+			error("ERROR: iBoot should be at boot stage 2, continuing anyway...\n");
+		}
+	}
+
 	unsigned long radio_error = 0;
 	irecv_getenv(client->recovery->client, "radio-error", &value);
 	if (value) {

--- a/src/restore.c
+++ b/src/restore.c
@@ -2123,7 +2123,7 @@ static plist_t restore_get_se_firmware_data(restored_client_t restore, struct id
 	}
 	if (chip_id == 0x20211) {
 		comp_name = "SE,Firmware";
-	} else if (chip_id == 0x73 || chip_id == 0x64 || chip_id == 0xC8 || chip_id == 0xD2) {
+	} else if (chip_id == 0x73 || chip_id == 0x64 || chip_id == 0xC8 || chip_id == 0xD2 || chip_id == 0x2C) {
 		comp_name = "SE,UpdatePayload";
 	} else {
 		info("WARNING: Unknown SE,ChipID 0x%" PRIx64 " detected. Restore might fail.\n", (uint64_t)chip_id);


### PR DESCRIPTION
This PR does the following:
- Add support for incoherent iBoot parameters. There are packets that declare isLoadedByiBootStage1 to true but isLoadedByiBoot to false. This makes the packet not being send at stage 1
- Add more info about current iBoot stage. This makes sure that we're really in stage 1 or 2 when we need to. It only displays an error if this is not the case, to make sure we don't break anything.
- Add Se,ChipID=0x2C for mac mini M2 pro
- Add PS190 firmware
- Add a generic TSS request generator that uses DeviceGeneratedData and DeviceGeneratedTags to automatically generate a TSS request. This should help us discover new packets when they arrive in future MacOS updates.