### PR TITLE
fix UAF

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -696,10 +696,10 @@ int _plist_dict_copy_item(plist_t target_dict, plist_t source_dict, const char *
 	return 0;
 }
 
-char* path_get_basename(char* path)
+const char* path_get_basename(const char* path)
 {
 #ifdef WIN32
-	char *p = path + strlen(path);
+	const char *p = path + strlen(path);
 	while (p > path) {
 		if ((*p == '/') || (*p == '\\')) {
 			return p+1;
@@ -708,7 +708,7 @@ char* path_get_basename(char* path)
 	}
 	return p;
 #else
-	char *p = strrchr(path, '/');
+	const char *p = strrchr(path, '/');
 	return p ? p + 1 : path;
 #endif
 }

--- a/src/common.h
+++ b/src/common.h
@@ -197,7 +197,7 @@ int _plist_dict_copy_data(plist_t target_dict, plist_t source_dict, const char *
 int _plist_dict_copy_string(plist_t target_dict, plist_t source_dict, const char *key, const char *alt_source_key);
 int _plist_dict_copy_item(plist_t target_dict, plist_t source_dict, const char *key, const char *alt_source_key);
 
-char* path_get_basename(char* path);
+const char* path_get_basename(const char* path);
 
 #ifdef __cplusplus
 }

--- a/src/idevicerestore.c
+++ b/src/idevicerestore.c
@@ -987,8 +987,7 @@ int idevicerestore_start(struct idevicerestore_client_t* client)
 			if (stat(client->cache_dir, &st) < 0) {
 				mkdir_with_parents(client->cache_dir, 0755);
 			}
-			char* ipsw_basename = path_get_basename(client->ipsw->path);
-			ipsw_basename = strdup(ipsw_basename);
+			char* ipsw_basename = strdup(path_get_basename(client->ipsw->path));
 			char* p = strrchr(ipsw_basename, '.');
 			if (p && isalpha(*(p+1))) {
 				*p = '\0';

--- a/src/restore.c
+++ b/src/restore.c
@@ -913,11 +913,11 @@ int restore_send_filesystem(struct idevicerestore_client_t* client, idevice_t de
 	}
 	if (client->filesystem) {
 		char* path = strdup(client->filesystem);
-		char* fsname_base = path_get_basename(path);
+		const char* fsname_base = path_get_basename(path);
 		char* parent_dir = dirname(path);
 		ipsw_dummy = ipsw_open(parent_dir);
-		free(path);
 		file = ipsw_file_open(ipsw_dummy, fsname_base);
+		free(path);
 	} else {
 		file = ipsw_file_open(client->ipsw, fsname);
 	}


### PR DESCRIPTION
Fix UAF

The relevant part is in the following original code:
```
if (client->filesystem) {
		char* path = strdup(client->filesystem);
		const char* fsname_base = path_get_basename(path);
		char* parent_dir = dirname(path);
		ipsw_dummy = ipsw_open(parent_dir);
		free(path); //this causes 'fsname_base' to be dangling!
		file = ipsw_file_open(ipsw_dummy, fsname_base); //fsname_base was freed in previous line
	}
```

The fix:
First call `ipsw_file_open` and only then call `free(path)`.
Furthermore to avoid this type of bug in future, change return type of `path_get_basename` to return a `const char*` (from simply `char*`).
This makes clear that the return value is immutable and moreover suggests that the return vale is **not** allocated and thus should be treated carefully.