### PR TITLE
FIXED PLIST_OPT_NONE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ stamp-h1
 src/.libs
 src/idevicerestore
 src/idevicerestore.exe
+.DS_Store

--- a/src/restore.c
+++ b/src/restore.c
@@ -51,7 +51,7 @@
 #include "common.h"
 #include "endianness.h"
 
-#define PLIST_OPT_NONE		       0
+#define PLIST_OPT_NONE				   0
 #define CREATE_PARTITION_MAP          11
 #define CREATE_FILESYSTEM             12
 #define RESTORE_IMAGE                 13

--- a/src/restore.c
+++ b/src/restore.c
@@ -51,6 +51,7 @@
 #include "common.h"
 #include "endianness.h"
 
+#define PLIST_OPT_NONE		       0
 #define CREATE_PARTITION_MAP          11
 #define CREATE_FILESYSTEM             12
 #define RESTORE_IMAGE                 13
@@ -114,7 +115,6 @@
 #define REQUESTING_EAN_DATA           74
 #define SEALING_SYSTEM_VOLUME         77
 #define UPDATING_APPLETCON            81
-#define PLIST_OPT_NONE		       0
 
 static int restore_finished = 0;
 

--- a/src/restore.c
+++ b/src/restore.c
@@ -114,7 +114,7 @@
 #define REQUESTING_EAN_DATA           74
 #define SEALING_SYSTEM_VOLUME         77
 #define UPDATING_APPLETCON            81
-#define PLIST_OPT_NONE				   0
+#define PLIST_OPT_NONE		       0
 
 static int restore_finished = 0;
 

--- a/src/restore.c
+++ b/src/restore.c
@@ -51,7 +51,7 @@
 #include "common.h"
 #include "endianness.h"
 
-#define PLIST_OPT_NONE				   0
+#define PLIST_OPT_NONE		       0
 #define CREATE_PARTITION_MAP          11
 #define CREATE_FILESYSTEM             12
 #define RESTORE_IMAGE                 13

--- a/src/restore.c
+++ b/src/restore.c
@@ -114,6 +114,7 @@
 #define REQUESTING_EAN_DATA           74
 #define SEALING_SYSTEM_VOLUME         77
 #define UPDATING_APPLETCON            81
+#define PLIST_OPT_NONE				   0
 
 static int restore_finished = 0;
 


### PR DESCRIPTION
Fixed the PLIST_OPT_NONE in 'recovery.c' on macOS which caused 'make' to fail

ERROR was:
restore.c:3455:69: error: use of undeclared identifier 'PLIST_OPT_NONE'
                plist_write_to_stream(unique_id_node, stdout, PLIST_FORMAT_PRINT, PLIST_OPT_NONE);