### PR TITLE
Fix building with LTO on Linux

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,7 +69,7 @@ if test "x$ac_cv_have_endian_h" = "xno"; then
   fi
 fi
 
-GLOBAL_CFLAGS="-Wno-multichar -O2"
+GLOBAL_CFLAGS="-Wno-multichar -O2 -lm"
 AC_LDADD=""
 AC_LDFLAGS=""
 


### PR DESCRIPTION
This fixes the following build failure when building with CFLAGS="-flto" on Linux

```
/usr/bin/ld: /tmp/cc9dX2xq.ltrans2.ltrans.o: undefined reference to symbol 'ceil@@GLIBC_2.2.5'
/usr/bin/ld: /usr/lib/libm.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```