### PR TITLE
Update idevicerestore.c

### DIFF
--- a/src/idevicerestore.c
+++ b/src/idevicerestore.c
@@ -1530,7 +1530,7 @@ int idevicerestore_start(struct idevicerestore_client_t* client)
 	if (client->mode != MODE_RESTORE) {
 		mutex_lock(&client->device_event_mutex);
 		info("Waiting for device to enter restore mode...\n");
-		cond_wait_timeout(&client->device_event_cond, &client->device_event_mutex, 180000);
+		cond_wait_timeout(&client->device_event_cond, &client->device_event_mutex, 240000);
 		if (client->mode != MODE_RESTORE || (client->flags & FLAG_QUIT)) {
 			mutex_unlock(&client->device_event_mutex);
 			error("ERROR: Device failed to enter restore mode.\n");


### PR DESCRIPTION
increased timeout to 4 mins for m4 mini restore (it was timing out before my m4 mini would return to recovery mode by about 30 seconds) - used with [BarbossHack/libimobiledevice-fedora](https://github.com/BarbossHack/libimobiledevice-fedora) on Fedora 42 to get around #733 