### PR TITLE
Improve type safety of new logging system and its handling of varargs

### DIFF
--- a/src/idevicerestore.c
+++ b/src/idevicerestore.c
@@ -1744,7 +1744,7 @@ static void plain_progress_func(struct progress_info_entry** progress_info, int 
 	}
 }
 
-static void tty_print(int level, const char* format, va_list varglist)
+static void tty_print(enum loglevel level, const char* fmt, va_list ap)
 {
 	switch (level) {
 		case 0:
@@ -1760,7 +1760,7 @@ static void tty_print(int level, const char* format, va_list varglist)
 			break;
 	}
 
-	cvfprintf(stdout, format, varglist);
+	cvfprintf(stdout, fmt, ap);
 
 	cprintf(COLOR_RESET);
 }

--- a/src/log.h
+++ b/src/log.h
@@ -30,11 +30,13 @@ enum loglevel {
 	LL_DEBUG
 };
 
-extern int log_level;
+extern enum loglevel log_level;
+
+typedef void (*logger_print_func)(enum loglevel level, const char*, va_list);
 
 void logger(enum loglevel level, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
 int logger_set_logfile(const char* path);
-void logger_set_print_func(void (*func)(int level, const char*, va_list));
+void logger_set_print_func(logger_print_func func);
 void logger_dump_hex(enum loglevel level, const void* buf, unsigned int len);
 void logger_dump_plist(enum loglevel level, plist_t plist, int human_readable);
 


### PR DESCRIPTION
- Replaced loglevel arguments and globals using the `int` type with the `loglevel` enum.
- Moved logging print func handler function declaration to typedef.
- Fixed misuse of `print_func` where a char* was passed in place of `va_list` via a wrapper function `print_funcf`.
- Fixed reuse of varargs in `logger` causing a segfault when `stderr_enabled` is true.
- Fixed length in `snprintf` call inside `logger_hex_dump` truncating the printed text.