### PR TITLE
fix: boot-args

### DIFF
--- a/src/recovery.c
+++ b/src/recovery.c
@@ -125,11 +125,11 @@ int recovery_set_autoboot(struct idevicerestore_client_t* client, int enable)
 
 int recovery_enter_restore(struct idevicerestore_client_t* client, plist_t build_identity)
 {
-	if (client->build_major >= 8) {
-		client->restore_boot_args = strdup("rd=md0 nand-enable-reformat=1rogress");
-	} else if (client->macos_variant) {
-		client->restore_boot_args = strdup("rd=md0 nand-enable-reformat=1 -progress -restore");
-	}
+    if (client->macos_variant) {
+        client->restore_boot_args = strdup("rd=md0 nand-enable-reformat=1 -progress -restore");
+    } else if (client->build_major >= 8) {
+        client->restore_boot_args = strdup("rd=md0 nand-enable-reformat=1 -progress");
+    }
 
 	/* upload data to make device boot restore mode */
 


### PR DESCRIPTION
- File src/recovery.c, function recovery_enter_restore:
    - Fixed the boot-args condition judgment order: prioritized matching the Apple Silicon/MacOS recovery path before the generic iOS path.
    - Corrected the spelling error: changed the incorrect `rd=md0 nand-enable-reformat=1rogress` to `rd=md0 nand-enable-reformat=1 -progress`.
- Repository-wide search confirmed that this was the only instance of the `1rogress` spelling error, which has now been fixed.