### PR TITLE
Ensure libirecovery API compatibility for current release

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -113,6 +113,21 @@ fi
 
 CFLAGS="$CACHED_CFLAGS"
 
+# check if libirecovery has irecv_init (older API)
+CACHED_CFLAGS2="$CFLAGS"
+CFLAGS+=" $libirecovery_CFLAGS"
+AC_CACHE_CHECK([for irecv_init in libirecovery], [ac_cv_have_irecv_init],
+	AC_TRY_COMPILE([
+		#include <libirecovery.h>
+		], [
+			irecv_init();
+			return 0;
+		], ac_cv_have_irecv_init=yes, ac_cv_have_irecv_init=no))
+if test "$ac_cv_have_irecv_init" = "yes"; then
+	AC_DEFINE([HAVE_IRECV_INIT], [1], [Define if libirecovery provides irecv_init])
+fi
+CFLAGS="$CACHED_CFLAGS2"
+
 AC_ARG_WITH([openssl],
             [AS_HELP_STRING([--without-openssl],
             [Do not use OpenSSL])],

--- a/src/common.h
+++ b/src/common.h
@@ -38,6 +38,13 @@ extern "C" {
 #include <plist/plist.h>
 #include <libirecovery.h>
 
+/* Backward compatibility for libirecovery API changes */
+#ifdef HAVE_IRECV_INIT
+#define IRECV_MAYBE_INIT() irecv_init()
+#else
+#define IRECV_MAYBE_INIT() ((void)0)
+#endif
+
 #include "idevicerestore.h"
 #include "thread.h"
 

--- a/src/dfu.c
+++ b/src/dfu.c
@@ -95,7 +95,7 @@ int dfu_check_mode(struct idevicerestore_client_t* client, int* mode) {
 		return -1;
 	}
 
-	irecv_init();
+	IRECV_MAYBE_INIT();
 	if (irecv_open_with_ecid(&dfu, client->ecid) != IRECV_E_SUCCESS) {
 		return -1;
 	}
@@ -119,7 +119,7 @@ irecv_device_t dfu_get_irecv_device(struct idevicerestore_client_t* client) {
 	irecv_error_t dfu_error = IRECV_E_SUCCESS;
 	irecv_device_t device = NULL;
 
-	irecv_init();
+	IRECV_MAYBE_INIT();
 	if (irecv_open_with_ecid(&dfu, client->ecid) != IRECV_E_SUCCESS) {
 		return NULL;
 	}

--- a/src/recovery.c
+++ b/src/recovery.c
@@ -108,7 +108,7 @@ int recovery_check_mode(struct idevicerestore_client_t* client) {
 		return -1;
 	}
 
-	irecv_init();
+	IRECV_MAYBE_INIT();
 	recovery_error=irecv_open_with_ecid(&recovery, client->ecid);
 
 	if (recovery_error != IRECV_E_SUCCESS) {


### PR DESCRIPTION
You will need to give this its own branch most likely. The aur package has started failing because the libirecovery aur package that is available is too new and causes version 1.0.0 to fail. Whilst I understand that a new release is in development and you may not wish to make a new release yet, I think at the very least this is a good compromise, it should work with old libirecovery versions, just like the current version, as well as newer versions of libirecovery. This should help prevent complaints that the current version is 'broken' and 'doesn't build' as more distros start to use the newer libirecovery versions, without harming other distros that choose to keep using older libirecovery versions

Adapts to API changes in libirecovery where the `irecv_init()` function may no longer be available or required.

Introduces a configure check to determine the presence of `irecv_init()`. `IRECV_MAYBE_INIT()`, is then used to conditionally call `irecv_init()` only if it exists, preventing build failures and ensuring proper behaviour across different versions of libirecovery.
