### PR TITLE
logger: fix crash and undefined behavior in logger_dump_hex with zero-length buffers

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -175,7 +175,15 @@ void logger_dump_hex(enum loglevel level, const void* buf, size_t len)
 
 	mutex_lock(&log_mutex);
 
-	fs = (char*)malloc(len * 3 + 1);
+	fs = (char*)malloc((len == 0) ? 2 : (len * 3 + 1));
+	if (!fs) {
+		mutex_unlock(&log_mutex);
+		return;
+	}
+	if (len == 0) {
+		fs[0] = '\n';
+		fs[1] = '\0';
+	}
 	for (unsigned int i = 0; i < len; i++) {
 		snprintf(fs + i*3, 4, "%02x%c", ((unsigned char*)buf)[i], (i < len-1) ? ' ' : '\n');
 	}


### PR DESCRIPTION
Fix undefined behavior and potential crash in logger_dump_hex() when called with a zero-length buffer.

Previously, the function allocated a 1-byte buffer but did not initialize it. This uninitialized buffer was later passed to %s formatting functions, causing an out-of-bounds read until a random null terminator was encountered. On Windows, this could trigger an access violation and crash the process.

This situation can occur when dumping nonces or other binary data if the reported length is zero due to device communication issues or unexpected conditions.