### PR TITLE
restore: Retry reverse proxy setup after device re-enumeration

### DIFF
--- a/src/restore.c
+++ b/src/restore.c
@@ -5269,6 +5269,29 @@ static void rp_status_cb(reverse_proxy_client_t client, reverse_proxy_status_t s
 {
 	logger(LL_VERBOSE, "ReverseProxy[%s]: (status=%d) %s\n", (reverse_proxy_get_type(client) == RP_TYPE_CTRL) ? "Ctrl" : "Conn", status, status_msg);
 }
+
+static int restore_wait_for_reconnect(struct idevicerestore_client_t* client)
+{
+	int i;
+	logger(LL_INFO, "Device is not responding, waiting for it to reappear on USB...\n");
+	if (client->restore->client) {
+		restored_client_free(client->restore->client);
+		client->restore->client = NULL;
+	}
+	if (client->restore->device) {
+		idevice_free(client->restore->device);
+		client->restore->device = NULL;
+	}
+	for (i = 0; i < 10; i++) {
+		sleep(1);
+		if (restore_open_with_timeout(client) == 0) {
+			logger(LL_INFO, "Device reappeared, reconnected to restored\n");
+			return 0;
+		}
+	}
+	logger(LL_ERROR, "Device did not reappear after 10 seconds\n");
+	return -1;
+}
 #endif
 
 int restore_device(struct idevicerestore_client_t* client, plist_t build_identity)
@@ -5368,29 +5391,41 @@ int restore_device(struct idevicerestore_client_t* client, plist_t build_identit
 #ifdef HAVE_REVERSE_PROXY
 	logger(LL_INFO, "Starting Reverse Proxy\n");
 	reverse_proxy_client_t rproxy = NULL;
-	if (reverse_proxy_client_create_with_port(device, &rproxy, REVERSE_PROXY_DEFAULT_PORT) != REVERSE_PROXY_E_SUCCESS) {
-		logger(LL_ERROR, "Could not create Reverse Proxy\n");
-	} else {
-		if (client->flags & FLAG_DEBUG) {
-			reverse_proxy_client_set_log_callback(rproxy, rp_log_cb, NULL);
-		}
-		reverse_proxy_client_set_status_callback(rproxy, rp_status_cb, NULL);
-		if (reverse_proxy_client_start_proxy(rproxy, 2) != REVERSE_PROXY_E_SUCCESS) {
-			logger(LL_ERROR, "Device didn't accept new reverse proxy protocol, trying to use old one\n");
-			reverse_proxy_client_free(rproxy);
-			rproxy = NULL;
-			if (reverse_proxy_client_create_with_port(device, &rproxy, REVERSE_PROXY_DEFAULT_PORT) != REVERSE_PROXY_E_SUCCESS) {
-				logger(LL_ERROR, "Could not create Reverse Proxy\n");
-			} else {
-				if (client->flags & FLAG_DEBUG) {
-					reverse_proxy_client_set_log_callback(rproxy, rp_log_cb, NULL);
-				}
-				reverse_proxy_client_set_status_callback(rproxy, rp_status_cb, NULL);
-				if (reverse_proxy_client_start_proxy(rproxy, 1) != REVERSE_PROXY_E_SUCCESS) {
-					logger(LL_ERROR, "ReverseProxy: Device didn't accept old protocol, giving up\n");
+	int rp_attempt;
+	for (rp_attempt = 0; rp_attempt < 2; rp_attempt++) {
+		if (reverse_proxy_client_create_with_port(device, &rproxy, REVERSE_PROXY_DEFAULT_PORT) != REVERSE_PROXY_E_SUCCESS) {
+			logger(LL_ERROR, "Could not create Reverse Proxy\n");
+		} else {
+			if (client->flags & FLAG_DEBUG) {
+				reverse_proxy_client_set_log_callback(rproxy, rp_log_cb, NULL);
+			}
+			reverse_proxy_client_set_status_callback(rproxy, rp_status_cb, NULL);
+			if (reverse_proxy_client_start_proxy(rproxy, 2) != REVERSE_PROXY_E_SUCCESS) {
+				logger(LL_ERROR, "Device didn't accept new reverse proxy protocol, trying to use old one\n");
+				reverse_proxy_client_free(rproxy);
+				rproxy = NULL;
+				if (reverse_proxy_client_create_with_port(device, &rproxy, REVERSE_PROXY_DEFAULT_PORT) != REVERSE_PROXY_E_SUCCESS) {
+					logger(LL_ERROR, "Could not create Reverse Proxy\n");
+				} else {
+					if (client->flags & FLAG_DEBUG) {
+						reverse_proxy_client_set_log_callback(rproxy, rp_log_cb, NULL);
+					}
+					reverse_proxy_client_set_status_callback(rproxy, rp_status_cb, NULL);
+					if (reverse_proxy_client_start_proxy(rproxy, 1) != REVERSE_PROXY_E_SUCCESS) {
+						logger(LL_ERROR, "ReverseProxy: Device didn't accept old protocol, giving up\n");
+					}
 				}
 			}
 		}
+		if (rproxy) {
+			break;
+		}
+		if (rp_attempt == 0 && restore_wait_for_reconnect(client) == 0) {
+			device = client->restore->device;
+			restore = client->restore->client;
+			continue;
+		}
+		break;
 	}
 #else
 	fdr_client_t fdr_control_channel = NULL;


### PR DESCRIPTION
Restoring iPadOS 26.6 (23G71) to an iPad 8 (iPad11,6) on Linux fails reproducibly with:

```
Starting Reverse Proxy
Device didn't accept new reverse proxy protocol, trying to use old one
Could not create Reverse Proxy
Unable to start the restore process
```

usbmuxd logs show the device dropping off the USB bus about 750 ms after entering restore mode and re-enumerating about 700 ms later. restore_device() has already connected to restored at that point, so the reverse proxy handshake runs straight into the disconnect. The failure is not a protocol rejection: after re-enumeration the idevice_t obtained in restore_open_with_timeout() refers to a stale usbmuxd device id, so the protocol version 1 fallback and the subsequent restored_start_restore() also fail immediately on the dead handle.

With this change, when reverse proxy setup fails, the stale restored/idevice handles are freed, restore_open_with_timeout() is polled for up to 10 seconds until the device reappears, and the reverse proxy setup is retried once with the fresh handles. The retry only triggers on a connection-level failure (rproxy == NULL); a device that genuinely rejects both protocol versions is not retried, and the normal path is unchanged.

Tested against the device above: 8 consecutive attempts failed identically without the patch, the first attempt with it succeeded end to end:

```
Starting Reverse Proxy
Could not create Reverse Proxy
Device is not responding, waiting for it to reappear on USB...
Device reappeared, reconnected to restored
DONE
```

Should fix #791, which reports the same device and failure signature.
